### PR TITLE
fix resolving request info for namespace resources

### DIFF
--- a/pkg/kubeapiserver/resource_handler.go
+++ b/pkg/kubeapiserver/resource_handler.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
-	kuberequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 
 	"github.com/clusterpedia-io/clusterpedia/pkg/kubeapiserver/discovery"
@@ -25,7 +25,7 @@ type ResourceHandler struct {
 }
 
 func (r *ResourceHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	requestInfo, ok := kuberequest.RequestInfoFrom(req.Context())
+	requestInfo, ok := genericrequest.RequestInfoFrom(req.Context())
 	if !ok {
 		responsewriters.ErrorNegotiated(
 			apierrors.NewInternalError(fmt.Errorf("no RequestInfo found in the context")),


### PR DESCRIPTION
when `get` a specified namespace, the `RequestInfo.Namespace` is set to thhe name of the namespace to get,
but the namespace resource is a cluster scope resource, so the `RequestInfo.Namespace` should be `""`

eg. The `kubectl --cluster cluster-1 get namespaces default` will fail because the resolved `RequestInfo.Namesapce` is not `""`, as follows:
```go
&RequestInfo{
  IsResourceRequest:true 
  Path:/api/v1/namespaces/default 
  Verb:get
  APIPrefix:api
  APIGroup: 
  APIVersion:v1 
  Namespace:default
  Resource:namespaces
  Subresource: 
  Name:default
  Parts:[namespaces default]
}
```
