### PR TITLE
[WIP] support setting the last resource version in the reflector

### DIFF
--- a/pkg/synchromanager/clustersynchro/informer/resourceversion_informer.go
+++ b/pkg/synchromanager/clustersynchro/informer/resourceversion_informer.go
@@ -24,7 +24,6 @@ func NewResourceVersionInformer(name string, lw cache.ListerWatcher, storage *Re
 		panic("name is required")
 	}
 
-	// storage: NewResourceVersionStorage(cache.DeletionHandlingMetaNamespaceKeyFunc),
 	informer := &resourceVersionInformer{
 		name:          name,
 		listerWatcher: lw,
@@ -46,7 +45,7 @@ func NewResourceVersionInformer(name string, lw cache.ListerWatcher, storage *Re
 			EmitDeltaTypeReplaced: true,
 		}),
 	}
-	informer.controller = NewNamedController(informer.name, config)
+	informer.controller = NewNamedController(informer.name, informer.storage, config)
 	return informer
 }
 

--- a/pkg/synchromanager/clustersynchro/informer/resourceversion_storage.go
+++ b/pkg/synchromanager/clustersynchro/informer/resourceversion_storage.go
@@ -1,23 +1,35 @@
 package informer
 
 import (
+	"strconv"
+	"sync/atomic"
+
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apiserver/pkg/storage/etcd3"
 	"k8s.io/client-go/tools/cache"
 )
 
 type ResourceVersionStorage struct {
 	keyFunc cache.KeyFunc
 
-	cacheStorage cache.ThreadSafeStore
+	lastResourceVersion *uint64
+	cacheStorage        cache.ThreadSafeStore
 }
 
 var _ cache.KeyListerGetter = &ResourceVersionStorage{}
 
 func NewResourceVersionStorage(keyFunc cache.KeyFunc) *ResourceVersionStorage {
-	return &ResourceVersionStorage{
-		cacheStorage: cache.NewThreadSafeStore(cache.Indexers{}, cache.Indices{}),
-		keyFunc:      keyFunc,
+	var lastResourceVersion uint64
+	storage := &ResourceVersionStorage{
+		keyFunc:             keyFunc,
+		lastResourceVersion: &lastResourceVersion,
+		cacheStorage:        cache.NewThreadSafeStore(cache.Indexers{}, cache.Indices{}),
 	}
+	return storage
+}
+
+func (c *ResourceVersionStorage) LastResourceVersion() string {
+	return strconv.FormatUint(atomic.LoadUint64(c.lastResourceVersion), 10)
 }
 
 func (c *ResourceVersionStorage) Add(obj interface{}) error {
@@ -25,12 +37,19 @@ func (c *ResourceVersionStorage) Add(obj interface{}) error {
 	if err != nil {
 		return cache.KeyError{Obj: obj, Err: err}
 	}
+
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err
 	}
 
-	c.cacheStorage.Add(key, accessor.GetResourceVersion())
+	resourceversion := accessor.GetResourceVersion()
+	rv, err := etcd3.Versioner.ParseResourceVersion(resourceversion)
+	if err != nil {
+		return err
+	}
+	atomic.CompareAndSwapUint64(c.lastResourceVersion, *c.lastResourceVersion, rv)
+	c.cacheStorage.Add(key, resourceversion)
 	return nil
 }
 
@@ -39,12 +58,19 @@ func (c *ResourceVersionStorage) Update(obj interface{}) error {
 	if err != nil {
 		return cache.KeyError{Obj: obj, Err: err}
 	}
+
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err
 	}
 
-	c.cacheStorage.Update(key, accessor.GetResourceVersion())
+	resourceversion := accessor.GetResourceVersion()
+	rv, err := etcd3.Versioner.ParseResourceVersion(resourceversion)
+	if err != nil {
+		return err
+	}
+	atomic.CompareAndSwapUint64(c.lastResourceVersion, *c.lastResourceVersion, rv)
+	c.cacheStorage.Update(key, resourceversion)
 	return nil
 }
 
@@ -80,6 +106,19 @@ func (c *ResourceVersionStorage) GetByKey(key string) (item interface{}, exists 
 }
 
 func (c *ResourceVersionStorage) Replace(versions map[string]interface{}) error {
+	var lastResourceVersion uint64
+	for _, version := range versions {
+		rv, err := etcd3.Versioner.ParseResourceVersion(version.(string))
+		if err != nil {
+			// TODO(iceber): handle err
+			continue
+		}
+
+		if rv > lastResourceVersion {
+			lastResourceVersion = rv
+		}
+	}
+	atomic.StoreUint64(c.lastResourceVersion, lastResourceVersion)
 	c.cacheStorage.Replace(versions, "")
 	return nil
 }


### PR DESCRIPTION
https://github.com/clusterpedia-io/clusterpedia/issues/5

The `clustersynchro` will automatically stop the synchronization of resources after two consecutive failed cluster health checks, and resume synchronization when the cluster is healthy.

In weak network environments, this may happen more frequently, and to avoid pulling all the data each time you start a resource sync, we need to support setting the reflector's field