### PR TITLE
prune managedFields and last-applied-configuration

### DIFF
--- a/cmd/clustersynchro-manager/app/synchro.go
+++ b/cmd/clustersynchro-manager/app/synchro.go
@@ -17,6 +17,7 @@ import (
 	"github.com/clusterpedia-io/clusterpedia/cmd/clustersynchro-manager/app/config"
 	"github.com/clusterpedia-io/clusterpedia/cmd/clustersynchro-manager/app/options"
 	"github.com/clusterpedia-io/clusterpedia/pkg/synchromanager"
+	clusterpediafeature "github.com/clusterpedia-io/clusterpedia/pkg/utils/feature"
 	"github.com/clusterpedia-io/clusterpedia/pkg/version/verflag"
 )
 
@@ -52,6 +53,7 @@ func NewClusterSynchroManagerCommand(ctx context.Context) *cobra.Command {
 	namedFlagSets := opts.Flags()
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	clusterpediafeature.MutableFeatureGate.AddFlag(namedFlagSets.FlagSet("mutable feature gate"))
 
 	fs := cmd.Flags()
 	for _, f := range namedFlagSets.FlagSets {

--- a/deploy/clusterpedia_clustersynchro_manager_deployment.yaml
+++ b/deploy/clusterpedia_clustersynchro_manager_deployment.yaml
@@ -27,6 +27,7 @@ spec:
         command:
         - /usr/local/bin/clustersynchro-manager
         - --storage-config=/etc/clusterpedia/storage/internalstorage-config.yaml
+        - --feature-gates PruneManagedFields=true,PruneLastAppliedConfiguration=true
         env:
         - name: DB_PASSWORD
           valueFrom:

--- a/pkg/synchromanager/features/features.go
+++ b/pkg/synchromanager/features/features.go
@@ -1,0 +1,40 @@
+package features
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+
+	clusterpediafeature "github.com/clusterpedia-io/clusterpedia/pkg/utils/feature"
+)
+
+const (
+	// Every feature gate should add method here following this template:
+	//
+	// // owner: @username
+	// // alpha: v0.X
+	// MyFeature featuregate.Feature = "MyFeature".
+
+	// PruneManagedFields is a feature gate for ClusterSynchro to prune `ManagedFields` of the resource
+	// https://kubernetes.io/docs/reference/using-api/server-side-apply/
+	//
+	// owner: @iceber
+	// alpha: v0.0.9
+	PruneManagedFields featuregate.Feature = "PruneManagedFields"
+
+	// PruneLastAppliedConfiguration is a feature gate for the ClusterSynchro to prune `LastAppliedConfiguration` of the resource
+	//
+	// owner: @iceber
+	// alpha: v0.0.9
+	PruneLastAppliedConfiguration featuregate.Feature = "PruneLastAppliedConfiguration"
+)
+
+func init() {
+	runtime.Must(clusterpediafeature.MutableFeatureGate.Add(defaultClusterSynchroManagerFeatureGates))
+}
+
+// defaultClusterSynchroManagerFeatureGates consists of all known clustersynchro-manager-specific feature keys.
+// To add a new feature, define a key for it above and add it here.
+var defaultClusterSynchroManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	PruneManagedFields:            {Default: false, PreRelease: featuregate.Alpha},
+	PruneLastAppliedConfiguration: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/pkg/utils/feature/gate.go
+++ b/pkg/utils/feature/gate.go
@@ -1,0 +1,15 @@
+package feature
+
+import (
+	"k8s.io/component-base/featuregate"
+)
+
+var (
+	// MutableFeatureGate is a mutable version of FeatureGate.
+	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
+	MutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// FeatureGate is a shared global FeatureGate.
+	// Top-level commands/options setup that needs to modify this featuregate gate should use MutableFeatureGate.
+	FeatureGate featuregate.FeatureGate = MutableFeatureGate
+)


### PR DESCRIPTION
The `clustersynchro` prunes fields based on `feature gate` when storing resources.
Pruning `managedFields` and `last-applied-configuration` annotation are supported.

```sh
./bin/clustersynchro-manager --feature-gates PruneManagedFields=true,PruneLastAppliedConfiguration=true 
```

Since the managedFields field is typically used very infrequently in resource searches, pruning prior to storage can also reduce the strain on storage and data transfer.

However, this may result in inconsistencies between the stored resources and the resource data in the member clusters.

issue: https://github.com/clusterpedia-io/clusterpedia/issues/4