### PR TITLE
fix cluster version

### DIFF
--- a/pkg/synchromanager/clustersynchro/cluster_synchro.go
+++ b/pkg/synchromanager/clustersynchro/cluster_synchro.go
@@ -85,6 +85,11 @@ func New(name string, config *rest.Config, storage storage.StorageFactory, updat
 		return nil, err
 	}
 
+	version, err := clusterclient.Discovery().ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+
 	resourceversions, err := storage.GetResourceVersions(context.TODO(), name)
 	if err != nil {
 		return nil, err
@@ -110,6 +115,7 @@ func New(name string, config *rest.Config, storage storage.StorageFactory, updat
 
 		resourceVersionCaches: make(map[schema.GroupVersionResource]*informer.ResourceVersionStorage),
 	}
+	synchro.version.Store(*version)
 	synchro.resourceSynchros.Store(map[schema.GroupVersionResource]*ResourceSynchro{})
 	synchro.resourceStatuses.Store(map[schema.GroupResource]*clustersv1alpha1.ClusterResourceStatus{})
 

--- a/pkg/synchromanager/clustersynchro_manager.go
+++ b/pkg/synchromanager/clustersynchro_manager.go
@@ -236,7 +236,7 @@ func (manager *Manager) reconcileCluster(cluster *clustersv1alpha1.PediaCluster)
 			// There are many reasons why creating a cluster synchro can fail.
 			// How do you gracefully handle different errors?
 
-			klog.ErrorS(err, "Failed to cluster synchro", "cluster", cluster.Name)
+			klog.ErrorS(err, "Failed to create cluster synchro", "cluster", cluster.Name)
 			// Not requeue
 			return nil
 		}


### PR DESCRIPTION
If the first health check fails, the version will not be set.
https://github.com/clusterpedia-io/clusterpedia/blob/c468ed371b5157f96ac8e639d1b971e49b88bf6d/pkg/synchromanager/clustersynchro/cluster_synchro.go#L515-L533

Calling the `genClusterStatus` when updating the cluster status results in a panic.
https://github.com/clusterpedia-io/clusterpedia/blob/c468ed371b5157f96ac8e639d1b971e49b88bf6d/pkg/synchromanager/clustersynchro/cluster_synchro.go#L414-L420