### PR TITLE
more parameters are supported when shutdowning the clustersynchro

### DIFF
--- a/pkg/synchromanager/clustersynchro_manager.go
+++ b/pkg/synchromanager/clustersynchro_manager.go
@@ -221,7 +221,7 @@ func (manager *Manager) reconcileCluster(cluster *clustersv1alpha1.PediaCluster)
 	if synchro != nil && !reflect.DeepEqual(synchro.RESTConfig, config) {
 		klog.InfoS("cluster config is changed, rebuild cluster synchro", "cluster", cluster.Name)
 
-		synchro.Shutdown()
+		synchro.Shutdown(false, false)
 		synchro = nil
 
 		// manager.cleanCluster(cluster.Name)
@@ -257,7 +257,9 @@ func (manager *Manager) removeCluster(name string) error {
 	manager.synchrolock.Unlock()
 
 	if synchro != nil {
-		synchro.Shutdown()
+		// not update removed cluster,
+		// and ensure that no more data is being synchronized to the resource storage
+		synchro.Shutdown(false, true)
 	}
 	return manager.cleanCluster(name)
 }


### PR DESCRIPTION
Support for setting two parameters `updateReadyCondition` and `waitResourceSynchro`, when closing the cluster synchronizer.
* `updateReadyCondition`
* If `updateReadyCondition` is true, the *pediacluster*'s ready condition status is updated to `Unknown`.
* If `waitResourceSynchro` is true,  wait for all resource synchros to shutdown, to ensure that no more data is synchronized to the storage.

It also ensures that we don't call `clustersynchro.updateStatus` and then close the `clustersynchro.status`.