### PR TITLE
fix clustersynchro manager deployment.

### DIFF
--- a/deploy/clusterpedia_clustersynchro_manager_deployment.yaml
+++ b/deploy/clusterpedia_clustersynchro_manager_deployment.yaml
@@ -27,7 +27,7 @@ spec:
         command:
         - /usr/local/bin/clustersynchro-manager
         - --storage-config=/etc/clusterpedia/storage/internalstorage-config.yaml
-        - --feature-gates PruneManagedFields=true,PruneLastAppliedConfiguration=true
+        - --feature-gates=PruneManagedFields=true,PruneLastAppliedConfiguration=true
         env:
         - name: DB_PASSWORD
           valueFrom:


### PR DESCRIPTION
fixed: #31

add the symbol `=` to the flag `--feature-gates`.

