### PR TITLE
support for the List object with remaining count and continue

### DIFF
--- a/pkg/apis/pedia/types.go
+++ b/pkg/apis/pedia/types.go
@@ -17,6 +17,9 @@ const (
 	SearchLabelNamespaces = "search.clusterpedia.io/namespaces"
 	SearchLabelOrderBy    = "search.clusterpedia.io/orderby"
 
+	SearchLabelWithContinue       = "search.clusterpedia.io/with-continue"
+	SearchLabelWithRemainingCount = "search.clusterpedia.io/with-remaining-count"
+
 	SearchLabelSize   = "search.clusterpedia.io/size"
 	SearchLabelOffset = "search.clusterpedia.io/offset"
 
@@ -38,6 +41,9 @@ type ListOptions struct {
 	ClusterNames []string
 	Namespaces   []string
 	OrderBy      []OrderBy
+
+	WithContinue       *bool
+	WithRemainingCount *bool
 
 	// +k8s:conversion-fn:drop
 	ExtraLabelSelector labels.Selector

--- a/pkg/apis/pedia/v1alpha1/conversion.go
+++ b/pkg/apis/pedia/v1alpha1/conversion.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/clusterpedia-io/clusterpedia/pkg/apis/pedia"
 )
@@ -38,6 +39,9 @@ func Convert_v1alpha1_ListOptions_To_pedia_ListOptions(in *ListOptions, out *ped
 	if err := convert_Slice_string_To_pedia_Slice_orderby(&orderbys, &out.OrderBy, " ", s); err != nil {
 		return err
 	}
+
+	out.WithContinue = in.WithContinue
+	out.WithRemainingCount = in.WithRemainingCount
 
 	if out.LabelSelector != nil {
 		var (
@@ -90,6 +94,18 @@ func Convert_v1alpha1_ListOptions_To_pedia_ListOptions(in *ListOptions, out *ped
 							return fmt.Errorf("Invalid Query Offset(%s): %w", out.Continue, err)
 						}
 					}
+				case pedia.SearchLabelWithContinue:
+					if in.WithContinue == nil && len(values) != 0 {
+						if err := runtime.Convert_Slice_string_To_Pointer_bool(&values, &out.WithContinue, s); err != nil {
+							return err
+						}
+					}
+				case pedia.SearchLabelWithRemainingCount:
+					if in.WithRemainingCount == nil && len(values) != 0 {
+						if err := runtime.Convert_Slice_string_To_Pointer_bool(&values, &out.WithRemainingCount, s); err != nil {
+							return err
+						}
+					}
 				default:
 					if strings.Contains(require.Key(), "clusterpedia.io") {
 						extraLabelRequest = append(extraLabelRequest, require)
@@ -136,6 +152,9 @@ func Convert_pedia_ListOptions_To_v1alpha1_ListOptions(in *pedia.ListOptions, ou
 	if err := convert_pedia_Slice_orderby_To_String(&in.OrderBy, &out.OrderBy, s); err != nil {
 		return err
 	}
+
+	out.WithContinue = in.WithContinue
+	out.WithRemainingCount = in.WithRemainingCount
 	return nil
 }
 

--- a/pkg/apis/pedia/v1alpha1/types.go
+++ b/pkg/apis/pedia/v1alpha1/types.go
@@ -32,6 +32,12 @@ type ListOptions struct {
 
 	// +optional
 	OrderBy string `json:"orderby,omitempty"`
+
+	// +optional
+	WithContinue *bool `json:"withContinue,omitempty"`
+
+	// +optional
+	WithRemainingCount *bool `json:"withRemainingCount,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/pedia/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/pedia/v1alpha1/zz_generated.conversion.go
@@ -193,6 +193,8 @@ func autoConvert_v1alpha1_ListOptions_To_pedia_ListOptions(in *ListOptions, out 
 	// WARNING: in.ClusterNames requires manual conversion: inconvertible types (string vs []string)
 	// WARNING: in.Namespaces requires manual conversion: inconvertible types (string vs []string)
 	// WARNING: in.OrderBy requires manual conversion: inconvertible types (string vs []github.com/clusterpedia-io/clusterpedia/pkg/apis/pedia.OrderBy)
+	out.WithContinue = (*bool)(unsafe.Pointer(in.WithContinue))
+	out.WithRemainingCount = (*bool)(unsafe.Pointer(in.WithRemainingCount))
 	return nil
 }
 
@@ -210,6 +212,8 @@ func autoConvert_pedia_ListOptions_To_v1alpha1_ListOptions(in *pedia.ListOptions
 		return err
 	}
 	// WARNING: in.OrderBy requires manual conversion: inconvertible types ([]github.com/clusterpedia-io/clusterpedia/pkg/apis/pedia.OrderBy vs string)
+	out.WithContinue = (*bool)(unsafe.Pointer(in.WithContinue))
+	out.WithRemainingCount = (*bool)(unsafe.Pointer(in.WithRemainingCount))
 	// WARNING: in.ExtraLabelSelector requires manual conversion: does not exist in peer-type
 	// WARNING: in.ExtraQuery requires manual conversion: does not exist in peer-type
 	return nil
@@ -252,6 +256,20 @@ func autoConvert_url_Values_To_v1alpha1_ListOptions(in *url.Values, out *ListOpt
 		}
 	} else {
 		out.OrderBy = ""
+	}
+	if values, ok := map[string][]string(*in)["withContinue"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_Pointer_bool(&values, &out.WithContinue, s); err != nil {
+			return err
+		}
+	} else {
+		out.WithContinue = nil
+	}
+	if values, ok := map[string][]string(*in)["withRemainingCount"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_Pointer_bool(&values, &out.WithRemainingCount, s); err != nil {
+			return err
+		}
+	} else {
+		out.WithRemainingCount = nil
 	}
 	return nil
 }

--- a/pkg/apis/pedia/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pedia/v1alpha1/zz_generated.deepcopy.go
@@ -99,6 +99,16 @@ func (in *CollectionResourceType) DeepCopy() *CollectionResourceType {
 func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 	*out = *in
 	in.ListOptions.DeepCopyInto(&out.ListOptions)
+	if in.WithContinue != nil {
+		in, out := &in.WithContinue, &out.WithContinue
+		*out = new(bool)
+		**out = **in
+	}
+	if in.WithRemainingCount != nil {
+		in, out := &in.WithRemainingCount, &out.WithRemainingCount
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/pedia/zz_generated.deepcopy.go
+++ b/pkg/apis/pedia/zz_generated.deepcopy.go
@@ -123,6 +123,16 @@ func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 		*out = make([]OrderBy, len(*in))
 		copy(*out, *in)
 	}
+	if in.WithContinue != nil {
+		in, out := &in.WithContinue, &out.WithContinue
+		*out = new(bool)
+		**out = **in
+	}
+	if in.WithRemainingCount != nil {
+		in, out := &in.WithRemainingCount, &out.WithRemainingCount
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ExtraLabelSelector != nil {
 		out.ExtraLabelSelector = in.ExtraLabelSelector.DeepCopySelector()
 	}

--- a/pkg/apiserver/registry/pedia/collectionresources/rest.go
+++ b/pkg/apiserver/registry/pedia/collectionresources/rest.go
@@ -88,6 +88,10 @@ func (s *REST) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runt
 	query := request.RequestQueryFrom(ctx)
 	pediascheme.ParameterCodec.DecodeParameters(query, pediav1alpha1.SchemeGroupVersion, &opts)
 
+	// collection resources don't support with remaining count
+	// ignore opts.WithRemainingCount
+	opts.WithRemainingCount = nil
+
 	storage, ok := s.storages[name]
 	if !ok {
 		return nil, errors.New("")

--- a/pkg/kubeapiserver/resourcerest/storage.go
+++ b/pkg/kubeapiserver/resourcerest/storage.go
@@ -84,17 +84,17 @@ func (s *RESTStorage) list(ctx context.Context, options *pediainternal.ListOptio
 		options.ClusterNames = []string{cluster}
 	}
 
+	/*
+		TODO(iceber): add feature gates to set default option
+		if options.WithRemainingCount == nil {
+		}
+	*/
+
 	objs := s.NewList()
 	if err := s.Storage.List(ctx, objs, options); err != nil {
 		return nil, storeerr.InterpretListError(err, s.DefaultQualifiedResource)
 	}
 
-	/*
-		list, err := meta.ListAccessor(objs)
-		if err != nil {
-			return nil, err
-		}
-	*/
 	return objs, nil
 }
 

--- a/pkg/storage/internalstorage/collectionresource_storage.go
+++ b/pkg/storage/internalstorage/collectionresource_storage.go
@@ -24,7 +24,7 @@ func (s *CollectionResourceStorage) Get(ctx context.Context, opts *pediainternal
 	cr := s.collectionResource.DeepCopy()
 
 	types := make(map[schema.GroupResource]*pediainternal.CollectionResourceType, len(cr.ResourceTypes))
-	query := s.db.WithContext(ctx).Where(&Resource{
+	query := s.db.WithContext(ctx).Model(&Resource{}).Where(&Resource{
 		Group:    cr.ResourceTypes[0].Group,
 		Version:  cr.ResourceTypes[0].Version,
 		Resource: cr.ResourceTypes[0].Resource,
@@ -39,7 +39,9 @@ func (s *CollectionResourceStorage) Get(ctx context.Context, opts *pediainternal
 
 		types[rt.GroupResource()] = &cr.ResourceTypes[i]
 	}
-	query = applyListOptionsToQuery(query, opts)
+
+	// TODO(iceber): support with remaining count and continue
+	_, _, query = applyListOptionsToQuery(query, opts)
 
 	var resources []Resource
 	result := query.Find(&resources)


### PR DESCRIPTION
add search label `search.clusterpedia.io/with-remaining-count` and `search.clusterpedia.io/with-continue`
|label|url query
|---|---|
|-selector  "`search.clusterpedia.io/with-remaining-count`=true"|`withRemainingCount`=true|
|--selector  "`search.clusterpedia.io/with-continue`=true"|`withContinue`=true|


example:
```bash
curl http://127.0.0.1:8080/api/v1/namespaces/default/pods?labelSelector=search.clusterpedia.io/with-remaining-count=true&limit=1&withContinue=true
{
    "kind": "PodList",
    "apiVersion": "v1",
    "metadata": {
        "continue": "1",
        "remainingItemCount": 1
    },
    "items": [
    ....
    ]
}
```