### PR TITLE
support field selector

### DIFF
--- a/pkg/apis/pedia/types.go
+++ b/pkg/apis/pedia/types.go
@@ -8,6 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/clusterpedia-io/clusterpedia/pkg/utils/fields"
 )
 
 const (
@@ -44,6 +46,9 @@ type ListOptions struct {
 
 	WithContinue       *bool
 	WithRemainingCount *bool
+
+	// +k8s:conversion-fn:drop
+	EnhancedFieldSelector fields.Selector
 
 	// +k8s:conversion-fn:drop
 	ExtraLabelSelector labels.Selector

--- a/pkg/apis/pedia/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/pedia/v1alpha1/zz_generated.conversion.go
@@ -214,6 +214,7 @@ func autoConvert_pedia_ListOptions_To_v1alpha1_ListOptions(in *pedia.ListOptions
 	// WARNING: in.OrderBy requires manual conversion: inconvertible types ([]github.com/clusterpedia-io/clusterpedia/pkg/apis/pedia.OrderBy vs string)
 	out.WithContinue = (*bool)(unsafe.Pointer(in.WithContinue))
 	out.WithRemainingCount = (*bool)(unsafe.Pointer(in.WithRemainingCount))
+	// WARNING: in.EnhancedFieldSelector requires manual conversion: does not exist in peer-type
 	// WARNING: in.ExtraLabelSelector requires manual conversion: does not exist in peer-type
 	// WARNING: in.ExtraQuery requires manual conversion: does not exist in peer-type
 	return nil

--- a/pkg/apis/pedia/zz_generated.deepcopy.go
+++ b/pkg/apis/pedia/zz_generated.deepcopy.go
@@ -133,6 +133,9 @@ func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnhancedFieldSelector != nil {
+		out.EnhancedFieldSelector = in.EnhancedFieldSelector.DeepCopySelector()
+	}
 	if in.ExtraLabelSelector != nil {
 		out.ExtraLabelSelector = in.ExtraLabelSelector.DeepCopySelector()
 	}

--- a/pkg/kubeapiserver/resource_handler.go
+++ b/pkg/kubeapiserver/resource_handler.go
@@ -114,6 +114,14 @@ func (r *ResourceHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		handler = handlers.GetResource(storage, reqScope)
 	case "list":
+		// remove fieldSelector query,
+		// prevent `handlers.ListResource` handling and verifying `FieldSelector`
+		// https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go#L198
+		originQuery := req.URL.Query()
+		if originQuery.Get("fieldSelector") != "" {
+			originQuery.Del("fieldSelector")
+			req.URL.RawQuery = originQuery.Encode()
+		}
 		handler = handlers.ListResource(storage, nil, reqScope, false, r.minRequestTimeout)
 	default:
 		responsewriters.ErrorNegotiated(

--- a/pkg/kubeapiserver/resourcerest/storage.go
+++ b/pkg/kubeapiserver/resourcerest/storage.go
@@ -67,6 +67,8 @@ func (s *RESTStorage) List(ctx context.Context, _ *metainternalversion.ListOptio
 		return nil, apierrors.NewBadRequest(err.Error())
 	}
 
+	// TODO(iceber): validate *pediainternal.ListOptions
+
 	return s.list(ctx, &opts)
 }
 

--- a/pkg/storage/internalstorage/collectionresource_storage.go
+++ b/pkg/storage/internalstorage/collectionresource_storage.go
@@ -41,7 +41,10 @@ func (s *CollectionResourceStorage) Get(ctx context.Context, opts *pediainternal
 	}
 
 	// TODO(iceber): support with remaining count and continue
-	_, _, query = applyListOptionsToQuery(query, opts)
+	_, _, query, err := applyListOptionsToQuery(query, opts)
+	if err != nil {
+		return nil, err
+	}
 
 	var resources []Resource
 	result := query.Find(&resources)

--- a/pkg/storage/internalstorage/register.go
+++ b/pkg/storage/internalstorage/register.go
@@ -18,8 +18,10 @@ import (
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
 )
 
+const StorageName = "internal"
+
 func init() {
-	storage.RegisterStorageFactoryFunc("internal", NewStorageFactory)
+	storage.RegisterStorageFactoryFunc(StorageName, NewStorageFactory)
 }
 
 func NewStorageFactory(configPath string) (storage.StorageFactory, error) {

--- a/pkg/storage/internalstorage/resource_storage.go
+++ b/pkg/storage/internalstorage/resource_storage.go
@@ -147,7 +147,10 @@ func (s *ResourceStorage) List(ctx context.Context, listObject runtime.Object, o
 		"version":  s.storageVersion.Version,
 		"resource": s.storageGroupResource.Resource,
 	})
-	offset, amount, query := applyListOptionsToQuery(query, opts)
+	offset, amount, query, err := applyListOptionsToQuery(query, opts)
+	if err != nil {
+		return err
+	}
 
 	var resources []Resource
 	result := query.Find(&resources)

--- a/pkg/utils/fields/lexer.go
+++ b/pkg/utils/fields/lexer.go
@@ -1,0 +1,150 @@
+/*
+	Copy from
+		https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/apimachinery/pkg/labels/selector.go#L452-L588
+*/
+
+package fields
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// string2token contains the mapping between lexer Token and token literal
+// (except IdentifierToken, EndOfStringToken and ErrorToken since it makes no sense)
+var string2token = map[string]labels.Token{
+	")":     labels.ClosedParToken,
+	",":     labels.CommaToken,
+	"!":     labels.DoesNotExistToken,
+	"==":    labels.DoubleEqualsToken,
+	"=":     labels.EqualsToken,
+	">":     labels.GreaterThanToken,
+	"in":    labels.InToken,
+	"<":     labels.LessThanToken,
+	"!=":    labels.NotEqualsToken,
+	"notin": labels.NotInToken,
+	"(":     labels.OpenParToken,
+}
+
+// ScannedItem contains the Token and the literal produced by the lexer.
+type ScannedItem struct {
+	tok     labels.Token
+	literal string
+}
+
+// isWhitespace returns true if the rune is a space, tab, or newline.
+func isWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n'
+}
+
+// isSpecialSymbol detects if the character ch can be an operator
+func isSpecialSymbol(ch byte) bool {
+	switch ch {
+	case '=', '!', '(', ')', ',', '>', '<':
+		return true
+	}
+	return false
+}
+
+// Lexer represents the Lexer struct for label selector.
+// It contains necessary informationt to tokenize the input string
+type Lexer struct {
+	// s stores the string to be tokenized
+	s string
+	// pos is the position currently tokenized
+	pos int
+}
+
+// read returns the character currently lexed
+// increment the position and check the buffer overflow
+func (l *Lexer) read() (b byte) {
+	b = 0
+	if l.pos < len(l.s) {
+		b = l.s[l.pos]
+		l.pos++
+	}
+	return b
+}
+
+// unread 'undoes' the last read character
+func (l *Lexer) unread() {
+	l.pos--
+}
+
+// scanIDOrKeyword scans string to recognize literal token (for example 'in') or an identifier.
+func (l *Lexer) scanIDOrKeyword() (tok labels.Token, lit string) {
+	var buffer []byte
+IdentifierLoop:
+	for {
+		switch ch := l.read(); {
+		case ch == 0:
+			break IdentifierLoop
+		case isSpecialSymbol(ch) || isWhitespace(ch):
+			l.unread()
+			break IdentifierLoop
+		default:
+			buffer = append(buffer, ch)
+		}
+	}
+	s := string(buffer)
+	if val, ok := string2token[s]; ok { // is a literal token?
+		return val, s
+	}
+	return labels.IdentifierToken, s // otherwise is an identifier
+}
+
+// scanSpecialSymbol scans string starting with special symbol.
+// special symbol identify non literal operators. "!=", "==", "="
+func (l *Lexer) scanSpecialSymbol() (labels.Token, string) {
+	lastScannedItem := ScannedItem{}
+	var buffer []byte
+SpecialSymbolLoop:
+	for {
+		switch ch := l.read(); {
+		case ch == 0:
+			break SpecialSymbolLoop
+		case isSpecialSymbol(ch):
+			buffer = append(buffer, ch)
+			if token, ok := string2token[string(buffer)]; ok {
+				lastScannedItem = ScannedItem{tok: token, literal: string(buffer)}
+			} else if lastScannedItem.tok != 0 {
+				l.unread()
+				break SpecialSymbolLoop
+			}
+		default:
+			l.unread()
+			break SpecialSymbolLoop
+		}
+	}
+	if lastScannedItem.tok == 0 {
+		return labels.ErrorToken, fmt.Sprintf("error expected: keyword found '%s'", buffer)
+	}
+	return lastScannedItem.tok, lastScannedItem.literal
+}
+
+// skipWhiteSpaces consumes all blank characters
+// returning the first non blank character
+func (l *Lexer) skipWhiteSpaces(ch byte) byte {
+	for {
+		if !isWhitespace(ch) {
+			return ch
+		}
+		ch = l.read()
+	}
+}
+
+// Lex returns a pair of Token and the literal
+// literal is meaningfull only for IdentifierToken token
+func (l *Lexer) Lex() (tok labels.Token, lit string) {
+	switch ch := l.skipWhiteSpaces(l.read()); {
+	case ch == 0:
+		return labels.EndOfStringToken, ""
+	case isSpecialSymbol(ch):
+		l.unread()
+		return l.scanSpecialSymbol()
+	default:
+		l.unread()
+		return l.scanIDOrKeyword()
+	}
+}

--- a/pkg/utils/fields/lexer_test.go
+++ b/pkg/utils/fields/lexer_test.go
@@ -1,0 +1,86 @@
+package fields
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestLexer(t *testing.T) {
+	testcases := []struct {
+		s string
+		t labels.Token
+	}{
+		{"", labels.EndOfStringToken},
+		{",", labels.CommaToken},
+		{"notin", labels.NotInToken},
+		{"in", labels.InToken},
+		{"=", labels.EqualsToken},
+		{"==", labels.DoubleEqualsToken},
+		{">", labels.GreaterThanToken},
+		{"<", labels.LessThanToken},
+		//Note that Lex returns the longest valid token found
+		{"!", labels.DoesNotExistToken},
+		{"!=", labels.NotEqualsToken},
+		{"(", labels.OpenParToken},
+		{")", labels.ClosedParToken},
+		//Non-"special" characters are considered part of an identifier
+		{"~", labels.IdentifierToken},
+		{"||", labels.IdentifierToken},
+	}
+	for _, v := range testcases {
+		l := &Lexer{s: v.s, pos: 0}
+		token, lit := l.Lex()
+		if token != v.t {
+			t.Errorf("Got %d it should be %d for '%s'", token, v.t, v.s)
+		}
+		if v.t != labels.ErrorToken && lit != v.s {
+			t.Errorf("Got '%s' it should be '%s'", lit, v.s)
+		}
+	}
+}
+
+func min(l, r int) (m int) {
+	m = r
+	if l < r {
+		m = l
+	}
+	return m
+}
+
+func TestLexerSequence(t *testing.T) {
+	testcases := []struct {
+		s string
+		t []labels.Token
+	}{
+		{"key in ( value )", []labels.Token{labels.IdentifierToken, labels.InToken, labels.OpenParToken, labels.IdentifierToken, labels.ClosedParToken}},
+		{"key notin ( value )", []labels.Token{labels.IdentifierToken, labels.NotInToken, labels.OpenParToken, labels.IdentifierToken, labels.ClosedParToken}},
+		{"key in ( value1, value2 )", []labels.Token{labels.IdentifierToken, labels.InToken, labels.OpenParToken, labels.IdentifierToken, labels.CommaToken, labels.IdentifierToken, labels.ClosedParToken}},
+		{"key", []labels.Token{labels.IdentifierToken}},
+		{"!key", []labels.Token{labels.DoesNotExistToken, labels.IdentifierToken}},
+		{"()", []labels.Token{labels.OpenParToken, labels.ClosedParToken}},
+		{"x in (),y", []labels.Token{labels.IdentifierToken, labels.InToken, labels.OpenParToken, labels.ClosedParToken, labels.CommaToken, labels.IdentifierToken}},
+		{"== != (), = notin", []labels.Token{labels.DoubleEqualsToken, labels.NotEqualsToken, labels.OpenParToken, labels.ClosedParToken, labels.CommaToken, labels.EqualsToken, labels.NotInToken}},
+		{"key>2", []labels.Token{labels.IdentifierToken, labels.GreaterThanToken, labels.IdentifierToken}},
+		{"key<1", []labels.Token{labels.IdentifierToken, labels.LessThanToken, labels.IdentifierToken}},
+	}
+	for _, v := range testcases {
+		var tokens []labels.Token
+		l := &Lexer{s: v.s, pos: 0}
+		for {
+			token, _ := l.Lex()
+			if token == labels.EndOfStringToken {
+				break
+			}
+			tokens = append(tokens, token)
+		}
+		if len(tokens) != len(v.t) {
+			t.Errorf("Bad number of tokens for '%s %d, %d", v.s, len(tokens), len(v.t))
+		}
+		for i := 0; i < min(len(tokens), len(v.t)); i++ {
+			if tokens[i] != v.t[i] {
+				t.Errorf("Test '%s': Mismatching in token type found '%v' it should be '%v'", v.s, tokens[i], v.t[i])
+			}
+		}
+	}
+}

--- a/pkg/utils/fields/parser.go
+++ b/pkg/utils/fields/parser.go
@@ -1,0 +1,270 @@
+/*
+	Reference from
+		https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/apimachinery/pkg/labels/selector.go#L590
+
+*/
+
+package fields
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	unaryOperators = []string{
+		string(selection.Exists), string(selection.DoesNotExist),
+	}
+	binaryOperators = []string{
+		string(selection.In), string(selection.NotIn),
+		string(selection.Equals), string(selection.DoubleEquals), string(selection.NotEquals),
+		string(selection.GreaterThan), string(selection.LessThan),
+	}
+	validRequirementOperators = append(binaryOperators, unaryOperators...)
+)
+
+type Parser struct {
+	l            *Lexer
+	scannedItems []ScannedItem
+	position     int
+}
+
+// ParserContext represents context during parsing:
+// some literal for example 'in' and 'notin' can be
+// recognized as operator for example 'x in (a)' but
+// it can be recognized as value for example 'value in (in)'
+type ParserContext int
+
+const (
+	// KeyAndOperator represents key and operator
+	KeyAndOperator ParserContext = iota
+	// Values represents values
+	Values
+)
+
+func (p *Parser) lookahead(context ParserContext) (labels.Token, string) {
+	tok, lit := p.scannedItems[p.position].tok, p.scannedItems[p.position].literal
+	if context == Values {
+		switch tok {
+		case labels.InToken, labels.NotInToken:
+			tok = labels.IdentifierToken
+		}
+	}
+	return tok, lit
+}
+
+func (p *Parser) consume(context ParserContext) (labels.Token, string) {
+	p.position++
+	tok, lit := p.scannedItems[p.position-1].tok, p.scannedItems[p.position-1].literal
+	if context == Values {
+		switch tok {
+		case labels.InToken, labels.NotInToken:
+			tok = labels.IdentifierToken
+		}
+	}
+	return tok, lit
+}
+
+func (p *Parser) scan() {
+	for {
+		token, literal := p.l.Lex()
+		p.scannedItems = append(p.scannedItems, ScannedItem{token, literal})
+		if token == labels.EndOfStringToken {
+			break
+		}
+	}
+}
+
+func (p *Parser) parse() ([]Requirement, error) {
+	p.scan()
+
+	var requirements []Requirement
+	for {
+		tok, lit := p.lookahead(Values)
+		switch tok {
+		case labels.IdentifierToken, labels.DoesNotExistToken:
+			r, err := p.parseRequirement()
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse requirement: %v", err)
+			}
+			requirements = append(requirements, *r)
+			t, l := p.consume(Values)
+			switch t {
+			case labels.EndOfStringToken:
+				return requirements, nil
+			case labels.CommaToken:
+				t2, l2 := p.lookahead(Values)
+				if t2 != labels.IdentifierToken && t2 != labels.DoesNotExistToken {
+					return nil, fmt.Errorf("found %q, expected: identifier after ','", l2)
+				}
+			default:
+				return nil, fmt.Errorf("found %q, expected: ',' or 'end of string'", l)
+			}
+		case labels.EndOfStringToken:
+			return requirements, nil
+		default:
+			return nil, fmt.Errorf("found %q, expected: !, identifier, or ''end of string", lit)
+		}
+	}
+}
+
+func (p *Parser) parseRequirement() (*Requirement, error) {
+	key, operator, err := p.parseKeyAndInferOperator()
+	if err != nil {
+		return nil, err
+	}
+	if operator == selection.Exists || operator == selection.DoesNotExist {
+		return NewRequirement(key, operator, []string{})
+	}
+
+	operator, err = p.parseOperator()
+	if err != nil {
+		return nil, err
+	}
+
+	var values sets.String
+	switch operator {
+	case selection.In, selection.NotIn:
+		values, err = p.parseValues()
+	case selection.Equals, selection.DoubleEquals, selection.NotEquals, selection.GreaterThan, selection.LessThan:
+		values, err = p.parseExactValue()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return NewRequirement(key, operator, values.List())
+}
+
+func (p *Parser) parseKeyAndInferOperator() (string, selection.Operator, error) {
+	var operator selection.Operator
+	tok, literal := p.consume(Values)
+	if tok == labels.DoesNotExistToken {
+		operator = selection.DoesNotExist
+		tok, literal = p.consume(Values)
+	}
+	if tok != labels.IdentifierToken {
+		return "", "", fmt.Errorf("found %q, expected: identifier", literal)
+	}
+
+	if t, _ := p.lookahead(Values); t == labels.EndOfStringToken || t == labels.CommaToken {
+		if operator != selection.DoesNotExist {
+			operator = selection.Exists
+		}
+	}
+	return literal, operator, nil
+}
+
+func (p *Parser) parseOperator() (op selection.Operator, err error) {
+	tok, lit := p.consume(KeyAndOperator)
+	switch tok {
+	// DoesNotExistToken shouldn't be here because it's a unary operator, not a binary operator
+	case labels.InToken:
+		op = selection.In
+	case labels.EqualsToken:
+		op = selection.Equals
+	case labels.DoubleEqualsToken:
+		op = selection.DoubleEquals
+	case labels.GreaterThanToken:
+		op = selection.GreaterThan
+	case labels.LessThanToken:
+		op = selection.LessThan
+	case labels.NotInToken:
+		op = selection.NotIn
+	case labels.NotEqualsToken:
+		op = selection.NotEquals
+	default:
+		return "", fmt.Errorf("found '%s', expected: %v", lit, strings.Join(binaryOperators, ", "))
+	}
+	return op, nil
+}
+
+func (p *Parser) parseValues() (sets.String, error) {
+	tok, lit := p.consume(Values)
+	if tok != labels.OpenParToken {
+		return nil, fmt.Errorf("found %q, expcted:'('", lit)
+	}
+
+	tok, lit = p.lookahead(Values)
+	switch tok {
+	case labels.IdentifierToken, labels.CommaToken:
+		s, err := p.parseIdentifiersList()
+		if err != nil {
+			return s, err
+		}
+		if tok, _ = p.consume(Values); tok != labels.ClosedParToken {
+			return nil, fmt.Errorf("found '%s', expectedd: ')'", lit)
+		}
+		return s, nil
+	case labels.ClosedParToken:
+		p.consume(Values)
+		return sets.NewString(""), nil
+	default:
+		return nil, fmt.Errorf("found %q, expected: ',', ')' or identifier", lit)
+	}
+}
+
+func (p *Parser) parseIdentifiersList() (sets.String, error) {
+	s := sets.NewString()
+	for {
+		tok, lit := p.consume(Values)
+		switch tok {
+		case labels.IdentifierToken:
+			s.Insert(lit)
+			tok2, lit2 := p.lookahead(Values)
+			switch tok2 {
+			case labels.CommaToken:
+				continue
+			case labels.ClosedParToken:
+				return s, nil
+			default:
+				return nil, fmt.Errorf("found %q, expected: ',' or ')'", lit2)
+			}
+		case labels.CommaToken:
+			if s.Len() == 0 {
+				s.Insert("") // to handle '(,'
+			}
+			tok2, _ := p.lookahead(Values)
+			if tok2 == labels.ClosedParToken {
+				s.Insert("") // to handle ',)' Double "" removed by StringSet
+				return s, nil
+			}
+			if tok2 == labels.CommaToken {
+				p.consume(Values)
+				s.Insert("") // to handle ,, Double "" removed by StringSet
+			}
+		default:
+			return s, fmt.Errorf("found %q, expected: ',',or identifier", lit)
+		}
+	}
+}
+
+func (p *Parser) parseExactValue() (sets.String, error) {
+	s := sets.NewString()
+	tok, _ := p.lookahead(Values)
+	if tok == labels.EndOfStringToken || tok == labels.CommaToken {
+		s.Insert("")
+		return s, nil
+	}
+	tok, lit := p.consume(Values)
+	if tok != labels.IdentifierToken {
+		return nil, fmt.Errorf("found %q, expected: identifier", lit)
+	}
+	s.Insert(lit)
+	return s, nil
+}
+
+// safeSort sorts input strings without modification
+func safeSort(in []string) []string {
+	if sort.StringsAreSorted(in) {
+		return in
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	sort.Strings(out)
+	return out
+}

--- a/pkg/utils/fields/parser_test.go
+++ b/pkg/utils/fields/parser_test.go
@@ -1,0 +1,90 @@
+package fields
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestSafeSort(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     []string
+		inCopy []string
+		want   []string
+	}{
+		{
+			name:   "nil strings",
+			in:     nil,
+			inCopy: nil,
+			want:   nil,
+		},
+		{
+			name:   "ordered strings",
+			in:     []string{"bar", "foo"},
+			inCopy: []string{"bar", "foo"},
+			want:   []string{"bar", "foo"},
+		},
+		{
+			name:   "unordered strings",
+			in:     []string{"foo", "bar"},
+			inCopy: []string{"foo", "bar"},
+			want:   []string{"bar", "foo"},
+		},
+		{
+			name:   "duplicated strings",
+			in:     []string{"foo", "bar", "foo", "bar"},
+			inCopy: []string{"foo", "bar", "foo", "bar"},
+			want:   []string{"bar", "bar", "foo", "foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := safeSort(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("safeSort() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.in, tt.inCopy) {
+				t.Errorf("after safeSort(), input = %v, want %v", tt.in, tt.inCopy)
+			}
+		})
+	}
+}
+
+func TestParserLookahead(t *testing.T) {
+	testcases := []struct {
+		s string
+		t []labels.Token
+	}{
+		{"key in ( value )", []labels.Token{labels.IdentifierToken, labels.InToken, labels.OpenParToken, labels.IdentifierToken, labels.ClosedParToken, labels.EndOfStringToken}},
+		{"key notin ( value )", []labels.Token{labels.IdentifierToken, labels.NotInToken, labels.OpenParToken, labels.IdentifierToken, labels.ClosedParToken, labels.EndOfStringToken}},
+		{"key in ( value1, value2 )", []labels.Token{labels.IdentifierToken, labels.InToken, labels.OpenParToken, labels.IdentifierToken, labels.CommaToken, labels.IdentifierToken, labels.ClosedParToken, labels.EndOfStringToken}},
+		{"key", []labels.Token{labels.IdentifierToken, labels.EndOfStringToken}},
+		{"!key", []labels.Token{labels.DoesNotExistToken, labels.IdentifierToken, labels.EndOfStringToken}},
+		{"()", []labels.Token{labels.OpenParToken, labels.ClosedParToken, labels.EndOfStringToken}},
+		{"", []labels.Token{labels.EndOfStringToken}},
+		{"x in (),y", []labels.Token{labels.IdentifierToken, labels.InToken, labels.OpenParToken, labels.ClosedParToken, labels.CommaToken, labels.IdentifierToken, labels.EndOfStringToken}},
+		{"== != (), = notin", []labels.Token{labels.DoubleEqualsToken, labels.NotEqualsToken, labels.OpenParToken, labels.ClosedParToken, labels.CommaToken, labels.EqualsToken, labels.NotInToken, labels.EndOfStringToken}},
+		{"key>2", []labels.Token{labels.IdentifierToken, labels.GreaterThanToken, labels.IdentifierToken, labels.EndOfStringToken}},
+		{"key<1", []labels.Token{labels.IdentifierToken, labels.LessThanToken, labels.IdentifierToken, labels.EndOfStringToken}},
+	}
+	for _, v := range testcases {
+		p := &Parser{l: &Lexer{s: v.s, pos: 0}, position: 0}
+		p.scan()
+		if len(p.scannedItems) != len(v.t) {
+			t.Errorf("Expected %d items found %d", len(v.t), len(p.scannedItems))
+		}
+		for {
+			token, lit := p.lookahead(KeyAndOperator)
+
+			token2, lit2 := p.consume(KeyAndOperator)
+			if token == labels.EndOfStringToken {
+				break
+			}
+			if token != token2 || lit != lit2 {
+				t.Errorf("Bad values")
+			}
+		}
+	}
+}

--- a/pkg/utils/fields/selector.go
+++ b/pkg/utils/fields/selector.go
@@ -1,0 +1,363 @@
+package fields
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+type Requirements []Requirement
+
+// Selector represents a label selector
+type Selector interface {
+	Empty() bool
+
+	String() string
+
+	// Add adds requirements to the Selector
+	Add(r ...Requirement) Selector
+
+	Requirements() (requirements Requirements, selectable bool)
+
+	// Make a deep copy of the selector.
+	DeepCopySelector() Selector
+}
+
+type internalSelector []Requirement
+
+func (s internalSelector) Empty() bool { return len(s) == 0 }
+
+func (s internalSelector) Requirements() (Requirements, bool) { return Requirements(s), true }
+
+func (s internalSelector) DeepCopy() internalSelector {
+	if s == nil {
+		return nil
+	}
+
+	// The `field.Path` struct is included in the `Field`,
+	// so DeepCopy becomes more complicated, and using `Parse`
+	// simplifies the logic.
+	result, _ := Parse(s.String())
+	return result.(internalSelector)
+}
+
+func (s internalSelector) DeepCopySelector() Selector {
+	return s.DeepCopy()
+}
+
+func (s internalSelector) Add(reqs ...Requirement) Selector {
+	ret := make(internalSelector, 0, len(s)+len(reqs))
+	ret = append(ret, s...)
+	ret = append(ret, reqs...)
+	sort.Sort(ByKey(ret))
+	return ret
+}
+
+func (s internalSelector) String() string {
+	var reqs []string
+	for ix := range s {
+		reqs = append(reqs, s[ix].String())
+	}
+	return strings.Join(reqs, ",")
+}
+
+// ByKey sorts requirements by key to obtain deterministic parser
+type ByKey []Requirement
+
+func (rs ByKey) Len() int { return len(rs) }
+
+func (rs ByKey) Swap(i, j int) { rs[i], rs[j] = rs[j], rs[i] }
+
+func (rs ByKey) Less(i, j int) bool { return rs[i].key < rs[j].key }
+
+type Requirement struct {
+	key string
+
+	fields    []Field
+	operator  selection.Operator
+	strValues []string
+}
+
+func NewRequirement(key string, op selection.Operator, vals []string) (*Requirement, error) {
+	fields, err := parseFields(key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) == 0 {
+		return nil, errors.New("fields is empty")
+	}
+
+	var allErrs field.ErrorList
+	for _, field := range fields {
+		if err := field.Validate(); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
+	lastField := fields[len(fields)-1]
+	path := lastField.Path()
+	if lastField.IsList() {
+		allErrs = append(allErrs, field.Invalid(path, lastField.Name(), "last field could not be list"))
+	}
+
+	valuePath := path.Child("values")
+	switch op {
+	case selection.In, selection.NotIn:
+		if len(vals) == 0 {
+			allErrs = append(allErrs, field.Invalid(valuePath, vals, "for 'in', 'notin' operators, values set can't be empty"))
+		}
+	case selection.Equals, selection.DoubleEquals, selection.NotEquals:
+		if len(vals) != 1 {
+			allErrs = append(allErrs, field.Invalid(valuePath, vals, "exact-match compatibility requires one single value"))
+		}
+	case selection.Exists, selection.DoesNotExist:
+		if len(vals) != 0 {
+			allErrs = append(allErrs, field.Invalid(valuePath, vals, "values set must be empty for exists and does not exist"))
+		}
+	case selection.GreaterThan, selection.LessThan:
+		if len(vals) != 1 {
+			allErrs = append(allErrs, field.Invalid(valuePath, vals, "for 'Gt', 'Lt' operators, exactly one value is required"))
+		}
+		for i := range vals {
+			if _, err := strconv.ParseInt(vals[i], 10, 64); err != nil {
+				allErrs = append(allErrs, field.Invalid(valuePath.Index(i), vals[i], "for 'Gt', 'Lt' operators, the value must be an integer"))
+			}
+		}
+	default:
+		allErrs = append(allErrs, field.NotSupported(path.Child("operator"), op, validRequirementOperators))
+	}
+
+	// values not validate
+
+	return &Requirement{key: key, fields: fields, operator: op, strValues: vals}, allErrs.ToAggregate()
+}
+
+func (r *Requirement) Fields() []Field {
+	fields := make([]Field, len(r.fields))
+	copy(fields, r.fields)
+	return fields
+}
+
+func (r *Requirement) Operator() selection.Operator {
+	return r.operator
+}
+
+func (r *Requirement) Values() sets.String {
+	ret := sets.String{}
+	for i := range r.strValues {
+		ret.Insert(r.strValues[i])
+	}
+	return ret
+}
+
+func (r *Requirement) String() string {
+	var sb strings.Builder
+	sb.Grow(
+		// length of r.key
+		len(r.key) +
+			// length of 'r.operator' + 2 spaces for the worst case ('in' and 'notin')
+			len(r.operator) + 2 +
+			// length of 'r.strValues' slice times. Heuristically 5 chars per word
+			+5*len(r.strValues))
+	if r.operator == selection.DoesNotExist {
+		sb.WriteString("!")
+	}
+	sb.WriteString(r.key)
+
+	switch r.operator {
+	case selection.Equals:
+		sb.WriteString("=")
+	case selection.DoubleEquals:
+		sb.WriteString("==")
+	case selection.NotEquals:
+		sb.WriteString("!=")
+	case selection.In:
+		sb.WriteString(" in ")
+	case selection.NotIn:
+		sb.WriteString(" notin ")
+	case selection.GreaterThan:
+		sb.WriteString(">")
+	case selection.LessThan:
+		sb.WriteString("<")
+	case selection.Exists, selection.DoesNotExist:
+		return sb.String()
+	}
+
+	switch r.operator {
+	case selection.In, selection.NotIn:
+		sb.WriteString("(")
+	}
+	if len(r.strValues) == 1 {
+		sb.WriteString(r.strValues[0])
+	} else { // only > 1 since == 0 prohibited by NewRequirement
+		// normalizes value order on output, without mutating the in-memory selector representation
+		// also avoids normalization when it is not required, and ensures we do not mutate shared data
+		sb.WriteString(strings.Join(safeSort(r.strValues), ","))
+	}
+
+	switch r.operator {
+	case selection.In, selection.NotIn:
+		sb.WriteString(")")
+	}
+	return sb.String()
+}
+
+type Field struct {
+	path *field.Path
+
+	name   string
+	isList bool
+	index  int
+}
+
+func NewField(parentPath *field.Path, name string) Field {
+	var path *field.Path
+	if parentPath == nil {
+		path = field.NewPath(name)
+	} else {
+		path = parentPath.Child(name)
+	}
+
+	return Field{path: path, name: name}
+}
+
+func (f *Field) setListIndex(index int) {
+	f.path = f.path.Index(index)
+	f.isList = true
+	f.index = index
+}
+
+func (f *Field) Name() string {
+	return f.name
+}
+
+func (f *Field) IsList() bool {
+	return f.isList
+}
+
+func (f *Field) GetListIndex() (int, bool) {
+	return f.index, f.isList
+}
+
+func (f *Field) Path() *field.Path {
+	return f.path
+}
+
+func (f *Field) Validate() *field.Error {
+	if errs := validation.IsQualifiedName(f.name); len(errs) != 0 {
+		return field.Invalid(f.path, f.name, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func parseFields(key string, fields []Field) ([]Field, error) {
+	if len(key) == 0 {
+		return fields, nil
+	}
+
+	if key[0] == '.' {
+		if len(key) == 1 {
+			return nil, errors.New("empty field after '.'")
+		}
+
+		key = key[1:]
+	}
+
+	var parentPath *field.Path
+	if len(fields) != 0 {
+		parentPath = fields[len(fields)-1].Path()
+	}
+
+	if key[0] == '[' {
+		rightIndex := strings.IndexByte(key, ']')
+		switch {
+		case rightIndex == -1:
+			return nil, errors.New("not found ']'")
+
+		// handle 'field[]'
+		case rightIndex == 1:
+			if len(fields) == 0 {
+				return nil, errors.New("empty [], not found list field")
+			}
+			fields[len(fields)-1].isList = true
+
+		// handle `lastfield['field']`
+		case key[1] == '\'' || key[1] == '"':
+			inSquKey := key[1:rightIndex]
+
+			wrap, inSquKey := inSquKey[0], inSquKey[1:]
+			rightSquIndex := strings.IndexByte(inSquKey, wrap)
+			switch rightSquIndex {
+			case -1:
+				return nil, fmt.Errorf("not found right '%c'", wrap)
+			case 1:
+				return nil, fmt.Errorf("empty field %c%c", wrap, wrap)
+			case len(inSquKey) - 1:
+				fields = append(fields, NewField(parentPath, inSquKey[0:rightSquIndex]))
+			default:
+				return nil, fmt.Errorf("invalid field ['%s]", inSquKey)
+			}
+
+		// handle 'field[0]'
+		default:
+			if len(fields) == 0 {
+				return nil, errors.New("[<index>], not found list field")
+			}
+			lastField := &fields[len(fields)-1]
+
+			indexStr := key[1:rightIndex]
+			index, err := strconv.Atoi(indexStr)
+			if err != nil {
+				return nil, fmt.Errorf("%s[<index>] list index invalid. if %s is a field, please use ['%s'] or .'%s'", lastField.Path(), indexStr, indexStr, indexStr)
+			}
+
+			lastField.setListIndex(index)
+		}
+		return parseFields(key[rightIndex+1:], fields)
+	}
+
+	if key[0] == '\'' || key[0] == '"' {
+		wrap := key[0]
+		if len(key) == 1 {
+			return nil, fmt.Errorf("not found right '%c'", wrap)
+		}
+
+		key = key[1:]
+		rightIndex := strings.IndexByte(key, wrap)
+		if rightIndex == -1 {
+			return nil, fmt.Errorf("not found right '%c'", wrap)
+		}
+		if rightIndex == 1 {
+			return nil, fmt.Errorf("empty field %c%c", wrap, wrap)
+		}
+
+		fields = append(fields, NewField(parentPath, key[0:rightIndex]))
+		return parseFields(key[rightIndex+1:], fields)
+	}
+
+	rightIndex := strings.IndexAny(key, ".[")
+	if rightIndex == -1 {
+		fields = append(fields, NewField(parentPath, key))
+		return fields, nil
+	}
+
+	fields = append(fields, NewField(parentPath, key[:rightIndex]))
+	return parseFields(key[rightIndex:], fields)
+}
+
+func Parse(selector string) (Selector, error) {
+	p := &Parser{l: &Lexer{s: selector, pos: 0}}
+	items, err := p.parse()
+	if err != nil {
+		return nil, err
+	}
+	sort.Sort(ByKey(items))
+	return internalSelector(items), nil
+}

--- a/pkg/utils/fields/selector_test.go
+++ b/pkg/utils/fields/selector_test.go
@@ -1,0 +1,72 @@
+package fields
+
+import (
+	"testing"
+)
+
+func TestParseFields(t *testing.T) {
+	testGoodStrings := []string{
+		"metadata.name",
+		".metadata.name",
+		".metadata.annotations.'test.io'",
+		".metadata.annotations['test.io']",
+		".field1['prefix.field2'].field3",
+		".field1['prefix.field2']['prefix.field3']",
+		".spec.containers[].name",
+		".spec.containers[0].name",
+		".field1['prefix.listed'][0].field2",
+	}
+	testBadStrings := []string{
+		"[]",
+		"[0]",
+		".metadata.annotations[test.io]",
+		".metadata.annotations['test.io'.go]",
+	}
+
+	for _, test := range testGoodStrings {
+		_, err := parseFields(test, nil)
+		if err != nil {
+			t.Errorf("%v: error %v\n", test, err)
+		}
+	}
+
+	for _, test := range testBadStrings {
+		_, err := parseFields(test, nil)
+		if err == nil {
+			t.Errorf("%v: did not get expected error\n", test)
+		}
+	}
+}
+
+func TestSelectorParse(t *testing.T) {
+	testGoodStrings := []string{
+		"",
+		".metadata.annotations['test.io'] in (value1,value2),.spec.replica=3",
+		"metadata.annotations.'test.io'==value1",
+		"!metadata.annotation['test.io']",
+		"spec.containers[].name!=container1",
+		".spec.containers[].name==container1",
+		".spec.containers[1].name in (container1,container2)",
+	}
+	testBadStrings := []string{
+		".metadata.annotations[test.io] in (value1, value2)",
+		".metadata.annotations['test'io'] in (value1, value2)",
+		"spec.containers[]==something",
+	}
+
+	for _, test := range testGoodStrings {
+		selector, err := Parse(test)
+		if err != nil {
+			t.Errorf("%v: error %v\n", test, err)
+		}
+		if test != selector.String() {
+			t.Errorf("%v restring gave: %v \n", test, selector.String())
+		}
+	}
+	for _, test := range testBadStrings {
+		_, err := Parse(test)
+		if err == nil {
+			t.Errorf("%v: did not get expected error\n", test)
+		}
+	}
+}


### PR DESCRIPTION
For `fieldSelector`, kubernetes currently only supports `metadata.name` and `metadata.namespace`,and the only operations supported are `=`, `!=`, `==`, which is a bit weak.

clusterpedia has enhanced its support for `fieldSelector`, and supports the same operations as `labelSelector`: `!`, `=` ,`!=`, `==`, `in`, `not in`

examples:
```bash
kubectl get pods --field-selector="status.phase=Running"

kubectl get pods --field-selector=".status.phase=Running"
```
Available whether or not it starts with `.`.

If the field contains the characters `.`, then you need to use `''`, `""` or `[' ']` to wrap
```bash
kubectl get deploy --field-selector="metadata.annotations['test.io'] in (value1,value2),spec.replica=3"

kubectl get deploy --field-selector="metadata.annotations.'test.io' in (value1,value2),spec.replica=3"
```

There is also support for list fields:
```bash
kubectl get po --field-selector="spec.containers[].name!=container1"

kubectl get po --field-selector="spec.containers[].name == container1"

kubectl get po --field-selector="spec.containers[1].name in (container1,container2)"
```
**But the `internalstorage` does not support list field filtering at this time.**

