### PR TITLE
internalstorage: add index and update sql where

### DIFF
--- a/pkg/storage/internalstorage/collectionresource_storage.go
+++ b/pkg/storage/internalstorage/collectionresource_storage.go
@@ -24,19 +24,18 @@ func (s *CollectionResourceStorage) Get(ctx context.Context, opts *pediainternal
 	cr := s.collectionResource.DeepCopy()
 
 	types := make(map[schema.GroupResource]*pediainternal.CollectionResourceType, len(cr.ResourceTypes))
-	query := s.db.WithContext(ctx).Model(&Resource{}).Where(&Resource{
-		Group:    cr.ResourceTypes[0].Group,
-		Version:  cr.ResourceTypes[0].Version,
-		Resource: cr.ResourceTypes[0].Resource,
+	query := s.db.WithContext(ctx).Model(&Resource{}).Where(map[string]interface{}{
+		"group":    cr.ResourceTypes[0].Group,
+		"version":  cr.ResourceTypes[0].Version,
+		"resource": cr.ResourceTypes[0].Resource,
 	})
 	types[cr.ResourceTypes[0].GroupResource()] = &cr.ResourceTypes[0]
 	for i, rt := range cr.ResourceTypes[1:] {
-		query.Or(&Resource{
-			Group:    rt.Group,
-			Version:  rt.Version,
-			Resource: rt.Resource,
+		query.Or(map[string]interface{}{
+			"group":    rt.Group,
+			"version":  rt.Version,
+			"resource": rt.Resource,
 		})
-
 		types[rt.GroupResource()] = &cr.ResourceTypes[i]
 	}
 

--- a/pkg/storage/internalstorage/errors.go
+++ b/pkg/storage/internalstorage/errors.go
@@ -51,6 +51,8 @@ func InterpreMysqlError(key string, err error) error {
 	switch mysqlErr.Number {
 	case 1062:
 		return genericstorage.NewKeyExistsError(key, 0)
+	case 1040:
+		// klog.Error("too many connections")
 	}
 	return err
 }

--- a/pkg/storage/internalstorage/register.go
+++ b/pkg/storage/internalstorage/register.go
@@ -60,7 +60,7 @@ func NewStorageFactory(configPath string) (storage.StorageFactory, error) {
 		return nil, err
 	}
 
-	db, err := gorm.Open(dialector, &gorm.Config{Logger: logger})
+	db, err := gorm.Open(dialector, &gorm.Config{SkipDefaultTransaction: true, Logger: logger})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Add index
* `idx_group_version_resource_namespace_name`
* `idx_group_version_resource_name`
* `idx_cluster`

The added index optimizes the filtering of namespace and name.
eg.
#### filter by namespace and name with index `idx_group_version_resource_namespace_name`
```sql
# mysql
SELECT * FROM resources WHERE `group`='apps' AND resource = 'deployments' AND version = 'v1' AND namespace in ('cert-manager', 'kube-system','default') AND name in ('cert-manager-cainjector', 'keycloak', 'keycloak-02') ORDER BY name,namespace,cluster desc,created_at,resource_version LIMIT 10

# postgres
SELECT * FROM resources WHERE "group"='apps' AND resource = 'deployments' AND version = 'v1' AND name in ('fake-resource-6-busybox-busybox', 'fake-resource-7-busyboxy-busybox') AND namespace in ('default','cert-manager','kube-system') ORDER BY name,namespace,cluster desc,created_at,resource_version LIMIT 10
```
#### filter by namespace with index `idx_group_version_resource_namespace_name`
```sql
# mysql
SELECT * FROM resources WHERE `group`='apps' AND resource = 'deployments' AND version = 'v1' AND namespace in ('cert-manager', 'kube-system','default')  ORDER BY name,namespace,cluster desc,created_at,resource_version ORDER BY name,namespace,cluster desc,created_at,resource_version LIMIT 10

# postgres
SELECT * FROM resources WHERE "group"='apps' AND resource = 'deployments' AND version = 'v1' AND  namespace in ('default','cert-manager','kube-system') ORDER BY name,namespace,cluster desc,created_at,resource_version LIMIT 10
```

#### filter by name with index `idx_group_version_resource_name`
```sql
# mysql
SELECT * FROM resources WHERE `group`='apps' AND resource = 'deployments' AND version = 'v1' AND name in ('cert-manager-cainjector', 'keycloak', 'keycloak-02') ORDER BY name,namespace,cluster desc,created_at,resource_version LIMIT 10
# postgres
SELECT * FROM resources WHERE "group"='apps' AND resource = 'deployments' AND version = 'v1' AND name in ('fake-resource-6-busybox-busybox', 'fake-resource-7-busyboxy-busybox') ORDER BY name,namespace,cluster desc,created_at,resource_version LIMIT 10
```

### Query with map
When querying with struct, GORM will only query with non-zero fields, that means if your field’s value is 0, '', false or other zero values, it won’t be used to build query conditions.
To include zero values in the query conditions, you can use a map, which will include all key-values as query conditions.

ref: https://gorm.io/docs/query.html#Struct-amp-Map-Conditions