### PR TITLE
internalstorage: cleanup sql builder for owner-key

### DIFF
--- a/pkg/storage/internalstorage/builder.go
+++ b/pkg/storage/internalstorage/builder.go
@@ -6,7 +6,6 @@ import (
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	"k8s.io/client-go/tools/cache"
 )
 
 type JSONQueryExpression struct {
@@ -128,17 +127,5 @@ func buildParentOwner(db *gorm.DB, cluster, owner string, seniority int) interfa
 	if _, ok := parentOwner.(string); ok {
 		return ownerQuery.Where("owner_uid = ?", parentOwner)
 	}
-	return ownerQuery.Where("owner_uid IN (?)", parentOwner)
-}
-
-// TODO(iceber): add gvr param
-func buildParentOwnerByKey(db *gorm.DB, cluster, ownerKey string, seniority int) interface{} {
-	ownerQuery := db.Model(Resource{}).Select("uid").Where(map[string]interface{}{"cluster": cluster})
-	if seniority == 0 {
-		namespace, name, _ := cache.SplitMetaNamespaceKey(ownerKey)
-		return ownerQuery.Where(map[string]interface{}{"namespace": namespace, "name": name})
-	}
-
-	parentOwner := buildParentOwnerByKey(db, cluster, ownerKey, seniority-1)
 	return ownerQuery.Where("owner_uid IN (?)", parentOwner)
 }


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

issue: https://github.com/clusterpedia-io/clusterpedia/issues/49

For the owner query does not need namespace, only owner name is needed,
and currently does not use the `buildParentOwnerByKey`, delete it.
> An owning object must be in the same namespace as the dependent, or be cluster-scoped.
