### PR TITLE
internalstorage: fix the sql builder for json

### DIFF
--- a/pkg/storage/internalstorage/builder.go
+++ b/pkg/storage/internalstorage/builder.go
@@ -51,7 +51,7 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 		switch stmt.Dialector.Name() {
 		case "mysql", "sqlite":
 			builder.WriteString("JSON_EXTRACT(" + stmt.Quote(jsonQuery.column) + ",")
-			builder.AddVar(stmt, "$."+strings.Join(jsonQuery.keys, "."))
+			builder.AddVar(stmt, fmt.Sprintf(`$."%s"`, strings.Join(jsonQuery.keys, `"."`)))
 
 			switch len(jsonQuery.values) {
 			case 0:

--- a/pkg/storage/internalstorage/util.go
+++ b/pkg/storage/internalstorage/util.go
@@ -55,8 +55,7 @@ func applyListOptionsToQuery(query *gorm.DB, opts *pediainternal.ListOptions, ap
 					values = append(values, value)
 				}
 
-				// wrap label key with `""`
-				jsonQuery := JSONQuery("object", "metadata", "labels", fmt.Sprintf("\"%s\"", requirement.Key()))
+				jsonQuery := JSONQuery("object", "metadata", "labels", requirement.Key())
 				switch requirement.Operator() {
 				case selection.Exists:
 				case selection.Equals, selection.DoubleEquals:


### PR DESCRIPTION
error mysql sql:
```sql
SELECT * FROM `resources` WHERE `group` = '' AND `resource` = 'pods' AND `version` = 'v1' AND namespace = 'default' AND JSON_EXTRACT(`object`,'$.metadata.annotations.dce.daocloud.io') = 'dao-2048' LIMIT 500
```
right mysql sql:
```sql
SELECT * FROM `resources` WHERE `group` = '' AND `resource` = 'pods' AND `version` = 'v1' AND namespace = 'default' AND JSON_EXTRACT(`object`,'$.metadata.annotations."dce.daocloud.io"') = 'dao-2048' LIMIT 500
```
