### PR TITLE
Trigger the push-image workflow on push tag

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
 jobs:
   images:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

The push-image workflow will run when we pushes a version tag that starts with v*