### PR TITLE
fix code for golangci-lint

### DIFF
--- a/pkg/apis/clusterpedia/v1beta1/conversion.go
+++ b/pkg/apis/clusterpedia/v1beta1/conversion.go
@@ -242,11 +242,12 @@ func convert_pedia_Slice_orderby_To_String(in *[]clusterpedia.OrderBy, out *stri
 	}
 
 	sliOrderBy := make([]string, len(*in))
-	for _, orderby := range *in {
+	for i, orderby := range *in {
 		str := orderby.Field
 		if orderby.Desc {
 			str += " desc"
 		}
+		sliOrderBy[i] = str
 	}
 
 	if err := convert_Slice_string_To_String(&sliOrderBy, out, s); err != nil {
@@ -254,8 +255,6 @@ func convert_pedia_Slice_orderby_To_String(in *[]clusterpedia.OrderBy, out *stri
 	}
 	return nil
 }
-
-func compileErrorOnMissingConversion() {}
 
 func convert_string_To_fields_Selector(in *string, out *fields.Selector, s conversion.Scope) error {
 	selector, err := fields.Parse(*in)
@@ -273,3 +272,6 @@ func convert_fields_Selector_To_string(in *fields.Selector, out *string, s conve
 	*out = (*in).String()
 	return nil
 }
+
+// nolint:unused
+func compileErrorOnMissingConversion() {}

--- a/pkg/apis/clusterpedia/v1beta1/types.go
+++ b/pkg/apis/clusterpedia/v1beta1/types.go
@@ -36,7 +36,7 @@ type ListOptions struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Resources struct {
-	metav1.TypeMeta `json:",line"`
+	metav1.TypeMeta `json:",inline"`
 }
 
 // +genclient

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -46,7 +46,7 @@ func init() {
 	// we need to add the options to empty v1
 	// TODO fix the server code to avoid this
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-	metainternal.AddToScheme(Scheme)
+	_ = metainternal.AddToScheme(Scheme)
 
 	// TODO: keep the generic API server from wanting this
 	unversioned := schema.GroupVersion{Group: "", Version: "v1"}

--- a/pkg/apiserver/registry/clusterpedia/collectionresources/rest.go
+++ b/pkg/apiserver/registry/clusterpedia/collectionresources/rest.go
@@ -86,7 +86,9 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 func (s *REST) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
 	var opts internal.ListOptions
 	query := request.RequestQueryFrom(ctx)
-	scheme.ParameterCodec.DecodeParameters(query, v1beta1.SchemeGroupVersion, &opts)
+	if err := scheme.ParameterCodec.DecodeParameters(query, v1beta1.SchemeGroupVersion, &opts); err != nil {
+		return nil, err
+	}
 
 	// collection resources don't support with remaining count
 	// ignore opts.WithRemainingCount

--- a/pkg/kubeapiserver/discovery/group.go
+++ b/pkg/kubeapiserver/discovery/group.go
@@ -145,7 +145,6 @@ func buildAPIGroups(groups sets.String, groupversions map[schema.GroupVersion]st
 				},
 			)
 		}
-
 	}
 
 	apiGroups := make(map[string]metav1.APIGroup, len(groups))

--- a/pkg/kubeapiserver/discovery/utils.go
+++ b/pkg/kubeapiserver/discovery/utils.go
@@ -54,9 +54,3 @@ func sortAPIGroupByName(groups []metav1.APIGroup) {
 		return groups[i].Name < groups[j].Name
 	})
 }
-
-func sortAPIReosurceByName(resources []metav1.APIResource) {
-	sort.Slice(resources, func(i, j int) bool {
-		return resources[i].Name < resources[j].Name
-	})
-}

--- a/pkg/kubeapiserver/resourcescheme/unstructured/scheme.go
+++ b/pkg/kubeapiserver/resourcescheme/unstructured/scheme.go
@@ -21,7 +21,7 @@ func (s *Scheme) New(kind schema.GroupVersionKind) (runtime.Object, error) {
 	return obj, nil
 }
 
-func (s *Scheme) Default(_ runtime.Object) { return }
+func (s *Scheme) Default(_ runtime.Object) {}
 
 // ObjectKinds returns a slice of one element with the group,version,kind of the
 // provided object, or an error if the object is not runtime.Unstructured or

--- a/pkg/kubeapiserver/storageconfig/storageconfig_factory.go
+++ b/pkg/kubeapiserver/storageconfig/storageconfig_factory.go
@@ -44,11 +44,13 @@ func NewStorageConfigFactory() *StorageConfigFactory {
 	return factory
 }
 
+/*
 func (f *StorageConfigFactory) addCohabitatingResources(groupResources ...schema.GroupResource) {
 	for _, groupResource := range groupResources {
 		f.cohabitatingResources[groupResource] = groupResources
 	}
 }
+*/
 
 func (g *StorageConfigFactory) GetStorageGroupResource(groupResource schema.GroupResource) schema.GroupResource {
 	if len(g.cohabitatingResources[groupResource]) != 0 {

--- a/pkg/storage/internalstorage/builder.go
+++ b/pkg/storage/internalstorage/builder.go
@@ -58,60 +58,60 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 
 		switch stmt.Dialector.Name() {
 		case "mysql", "sqlite":
-			builder.WriteString("JSON_UNQUOTE(JSON_EXTRACT(" + stmt.Quote(jsonQuery.column) + ",")
+			writeString(builder, "JSON_UNQUOTE(JSON_EXTRACT("+stmt.Quote(jsonQuery.column)+",")
 			builder.AddVar(stmt, fmt.Sprintf(`$."%s"`, strings.Join(jsonQuery.keys, `"."`)))
-			builder.WriteString("))")
+			writeString(builder, "))")
 
 			switch len(jsonQuery.values) {
 			case 0:
 				if jsonQuery.not {
-					builder.WriteString(" IS NULL")
+					writeString(builder, " IS NULL")
 				} else {
-					builder.WriteString(" IS NOT NULL")
+					writeString(builder, " IS NOT NULL")
 				}
 			case 1:
 				if jsonQuery.not {
-					builder.WriteString(" != ")
+					writeString(builder, " != ")
 				} else {
-					builder.WriteString(" = ")
+					writeString(builder, " = ")
 				}
 				builder.AddVar(builder, jsonQuery.values[0])
 			default:
 				if jsonQuery.not {
-					builder.WriteString(" NOT IN ")
+					writeString(builder, " NOT IN ")
 				} else {
-					builder.WriteString(" IN ")
+					writeString(builder, " IN ")
 				}
 				builder.AddVar(builder, jsonQuery.values)
 			}
 		case "postgres":
 			stmt.WriteQuoted(jsonQuery.column)
 			for _, key := range jsonQuery.keys[0 : len(jsonQuery.keys)-1] {
-				stmt.WriteString(" -> ")
+				writeString(stmt, " -> ")
 				stmt.AddVar(builder, key)
 			}
-			stmt.WriteString(" ->> ")
+			writeString(stmt, " ->> ")
 			stmt.AddVar(builder, jsonQuery.keys[len(jsonQuery.keys)-1])
 
 			switch len(jsonQuery.values) {
 			case 0:
 				if jsonQuery.not {
-					stmt.WriteString(" IS NULL")
+					writeString(stmt, " IS NULL")
 				} else {
-					stmt.WriteString(" IS NOT NULL")
+					writeString(stmt, " IS NOT NULL")
 				}
 			case 1:
 				if jsonQuery.not {
-					stmt.WriteString(" != ")
+					writeString(stmt, " != ")
 				} else {
-					stmt.WriteString(" = ")
+					writeString(stmt, " = ")
 				}
 				builder.AddVar(builder, jsonQuery.values[0])
 			default:
 				if jsonQuery.not {
-					builder.WriteString(" NOT IN ")
+					writeString(builder, " NOT IN ")
 				} else {
-					builder.WriteString(" IN ")
+					writeString(builder, " IN ")
 				}
 				builder.AddVar(builder, jsonQuery.values)
 			}
@@ -130,4 +130,8 @@ func buildParentOwner(db *gorm.DB, cluster, owner string, seniority int) interfa
 		return ownerQuery.Where("owner_uid = ?", parentOwner)
 	}
 	return ownerQuery.Where("owner_uid IN (?)", parentOwner)
+}
+
+func writeString(builder clause.Writer, str string) {
+	_, _ = builder.WriteString(str)
 }

--- a/pkg/storage/internalstorage/config.go
+++ b/pkg/storage/internalstorage/config.go
@@ -102,7 +102,9 @@ func (cfg *Config) genMySQLConfig() (*mysql.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	mysql.RegisterTLSConfig(cfg.SSLMode, tlsConfig)
+	if err := mysql.RegisterTLSConfig(cfg.SSLMode, tlsConfig); err != nil {
+		return nil, err
+	}
 
 	mysqlconfig := mysql.NewConfig()
 	mysqlconfig.User = cfg.User

--- a/pkg/synchromanager/clustersynchro/cluster_synchro.go
+++ b/pkg/synchromanager/clustersynchro/cluster_synchro.go
@@ -144,7 +144,7 @@ func (s *ClusterSynchro) initWithResourceVersions(resourceversions map[schema.Gr
 	resourceVersionCaches := make(map[schema.GroupVersionResource]*informer.ResourceVersionStorage, len(resourceversions))
 	for gvr, rvs := range resourceversions {
 		cache := informer.NewResourceVersionStorage(cache.DeletionHandlingMetaNamespaceKeyFunc)
-		cache.Replace(rvs)
+		_ = cache.Replace(rvs)
 		resourceVersionCaches[gvr] = cache
 	}
 

--- a/pkg/synchromanager/clustersynchro/informer/named_controller.go
+++ b/pkg/synchromanager/clustersynchro/informer/named_controller.go
@@ -61,7 +61,7 @@ func (c *controller) processLoop() {
 			}
 			if c.config.RetryOnError {
 				// This is the safe way to re-enqueue.
-				c.config.Queue.AddIfNotPresent(obj)
+				_ = c.config.Queue.AddIfNotPresent(obj)
 			}
 		}
 	}

--- a/pkg/synchromanager/clustersynchro/queue/event.go
+++ b/pkg/synchromanager/clustersynchro/queue/event.go
@@ -45,11 +45,12 @@ func pressureEvents(older *Event, newer *Event) *Event {
 			return newer
 		}
 
-		if older.Action == Updated {
-			// TODO(clusterpedia-io)
-			// 正常来说 Updated -> Added 之间，会存在一个 Deleted 事件
-		}
-
+		/*
+			if older.Action == Updated {
+				// TODO(iceber)
+				// 正常来说 Updated -> Added 之间，会存在一个 Deleted 事件
+			}
+		*/
 		return newer
 	}
 

--- a/pkg/utils/request/clustername.go
+++ b/pkg/utils/request/clustername.go
@@ -2,7 +2,9 @@ package request
 
 import "context"
 
-const clusterNameKey = "cluster-name"
+type clusterKeyType int
+
+const clusterNameKey clusterKeyType = iota
 
 func WithClusterName(parent context.Context, name string) context.Context {
 	return context.WithValue(parent, clusterNameKey, name)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -43,8 +43,6 @@ func GetKubeVersion() apimachineryversion.Info {
 	// k3s-io/kubernetes/staging/src/k8s.io/component-base/version.gitVersion is "v0.0.0-k3s1"
 	// remove suffix '-k3s1'
 	version := componentbaseversion.Get()
-	if strings.HasSuffix(version.GitVersion, "-k3s1") {
-		version.GitVersion = strings.TrimSuffix(version.GitVersion, "-k3s1")
-	}
+	version.GitVersion = strings.TrimSuffix(version.GitVersion, "-k3s1")
 	return version
 }


### PR DESCRIPTION
```console
$  make lint
/Users/icebergu/go/bin/golangci-lint run
pkg/apis/clusterpedia/v1beta1/conversion.go:248:4: ineffectual assignment to str (ineffassign)
                        str += " desc"
                        ^
pkg/apis/clusterpedia/v1beta1/conversion.go:258:6: func `compileErrorOnMissingConversion` is unused (unused)
func compileErrorOnMissingConversion() {}
     ^
pkg/apis/clusterpedia/v1beta1/types.go:39:18: SA5008: unknown JSON option "line" (staticcheck)
        metav1.TypeMeta `json:",line"`
                        ^
pkg/apiserver/apiserver.go:49:26: Error return value is not checked (errcheck)
        metainternal.AddToScheme(Scheme)
                                ^
pkg/apiserver/registry/clusterpedia/collectionresources/rest.go:89:40: Error return value of `scheme.ParameterCodec.DecodeParameters` is not checked (errcheck)
        scheme.ParameterCodec.DecodeParameters(query, v1beta1.SchemeGroupVersion, &opts)
                                              ^
pkg/kubeapiserver/discovery/group.go:148: unnecessary trailing newline (whitespace)

        }
pkg/kubeapiserver/discovery/utils.go:58:6: `sortAPIReosurceByName` is unused (deadcode)
func sortAPIReosurceByName(resources []metav1.APIResource) {
     ^
pkg/kubeapiserver/resourcescheme/unstructured/scheme.go:24:46: S1023: redundant `return` statement (gosimple)
func (s *Scheme) Default(_ runtime.Object) { return }
                                             ^
pkg/kubeapiserver/storageconfig/storageconfig_factory.go:47:32: func `(*StorageConfigFactory).addCohabitatingResources` is unused (unused)
func (f *StorageConfigFactory) addCohabitatingResources(groupResources ...schema.GroupResource) {
                               ^
pkg/storage/internalstorage/builder.go:61:23: Error return value of `builder.WriteString` is not checked (errcheck)
                        builder.WriteString("JSON_UNQUOTE(JSON_EXTRACT(" + stmt.Quote(jsonQuery.column) + ",")
                                           ^
pkg/storage/internalstorage/builder.go:63:23: Error return value of `builder.WriteString` is not checked (errcheck)
                        builder.WriteString("))")
                                           ^
pkg/storage/internalstorage/builder.go:68:25: Error return value of `builder.WriteString` is not checked (errcheck)
                                        builder.WriteString(" IS NULL")
                                                           ^
pkg/storage/internalstorage/builder.go:90:21: Error return value of `stmt.WriteString` is not checked (errcheck)
                                stmt.WriteString(" -> ")
                                                ^
pkg/storage/internalstorage/builder.go:93:20: Error return value of `stmt.WriteString` is not checked (errcheck)
                        stmt.WriteString(" ->> ")
                                        ^
pkg/storage/internalstorage/builder.go:99:22: Error return value of `stmt.WriteString` is not checked (errcheck)
                                        stmt.WriteString(" IS NULL")
                                                        ^
pkg/storage/internalstorage/config.go:105:25: Error return value of `mysql.RegisterTLSConfig` is not checked (errcheck)
        mysql.RegisterTLSConfig(cfg.SSLMode, tlsConfig)
                               ^
pkg/synchromanager/clustersynchro/cluster_synchro.go:147:16: Error return value of `cache.Replace` is not checked (errcheck)
                cache.Replace(rvs)
                             ^
pkg/synchromanager/clustersynchro/informer/named_controller.go:64:35: Error return value of `c.config.Queue.AddIfNotPresent` is not checked (errcheck)
                                c.config.Queue.AddIfNotPresent(obj)
                                                              ^
pkg/synchromanager/clustersynchro/queue/event.go:48:3: SA9003: empty branch (staticcheck)
                if older.Action == Updated {
                ^
pkg/synchromanager/clustersynchro/resource_synchro.go:215:19: Error return value of `synchro.queue.Add` is not checked (errcheck)
        synchro.queue.Add(obj)
                         ^
pkg/synchromanager/clustersynchro/resource_synchro.go:226:22: Error return value of `synchro.queue.Update` is not checked (errcheck)
        synchro.queue.Update(obj)
                            ^
pkg/synchromanager/clustersynchro/resource_synchro.go:230:22: Error return value of `synchro.queue.Delete` is not checked (errcheck)
        synchro.queue.Delete(obj)
                            ^
pkg/synchromanager/clustersynchro/resource_synchro.go:275:26: Error return value of `synchro.queue.Done` is not checked (errcheck)
        defer synchro.queue.Done(event)
                                ^
pkg/synchromanager/clustersynchro/resource_synchro.go:290:25: Error return value of `synchro.deleteResource` is not checked (errcheck)
                synchro.deleteResource(obj)
                                      ^
pkg/utils/request/clustername.go:8:35: SA1029: should not use built-in type string as key for value; define your own type to avoid collisions (staticcheck)
        return context.WithValue(parent, clusterNameKey, name)
                                         ^
pkg/version/version.go:46:2: S1017: should replace this if statement with an unconditional strings.TrimSuffix (gosimple)
        if strings.HasSuffix(version.GitVersion, "-k3s1") {
        ^
make: *** [lint] Error 1
```