### PR TITLE
search by owner's resource.group and name

### DIFF
--- a/pkg/apis/clusterpedia/types.go
+++ b/pkg/apis/clusterpedia/types.go
@@ -13,11 +13,15 @@ import (
 )
 
 const (
-	SearchLabelOwner      = "search.clusterpedia.io/owner"
 	SearchLabelNames      = "search.clusterpedia.io/names"
 	SearchLabelClusters   = "search.clusterpedia.io/clusters"
 	SearchLabelNamespaces = "search.clusterpedia.io/namespaces"
 	SearchLabelOrderBy    = "search.clusterpedia.io/orderby"
+
+	SearchLabelOwnerUID           = "search.clusterpedia.io/owner-uid"
+	SearchLabelOwnerName          = "search.clusterpedia.io/owner-name"
+	SearchLabelOwnerGroupResource = "search.clusterpedia.io/owner-gr"
+	SearchLabelOwnerSeniority     = "search.clusterpedia.io/owner-seniority"
 
 	SearchLabelWithContinue       = "search.clusterpedia.io/with-continue"
 	SearchLabelWithRemainingCount = "search.clusterpedia.io/with-remaining-count"
@@ -39,10 +43,14 @@ type ListOptions struct {
 	metainternal.ListOptions
 
 	Names        []string
-	Owner        string
 	ClusterNames []string
 	Namespaces   []string
 	OrderBy      []OrderBy
+
+	OwnerName          string
+	OwnerUID           string
+	OwnerGroupResource schema.GroupResource
+	OwnerSeniority     int
 
 	WithContinue       *bool
 	WithRemainingCount *bool

--- a/pkg/apis/clusterpedia/v1beta1/types.go
+++ b/pkg/apis/clusterpedia/v1beta1/types.go
@@ -15,9 +15,6 @@ type ListOptions struct {
 	Names string `json:"names,omitempty"`
 
 	// +optional
-	Owner string `json:"owner,omitempty"`
-
-	// +optional
 	ClusterNames string `json:"clusters,omitempty"`
 
 	// +optional
@@ -25,6 +22,18 @@ type ListOptions struct {
 
 	// +optional
 	OrderBy string `json:"orderby,omitempty"`
+
+	// +optional
+	OwnerUID string `json:"ownerUID,omitempty"`
+
+	// +optional
+	OwnerName string `json:"ownerName,omitempty"`
+
+	// +optional
+	OwnerGroupResource string `json:"ownerGR,omitempty"`
+
+	// +optional
+	OwnerSeniority int `json:"ownerSeniority,omitempty"`
 
 	// +optional
 	WithContinue *bool `json:"withContinue,omitempty"`

--- a/pkg/apis/clusterpedia/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/clusterpedia/v1beta1/zz_generated.conversion.go
@@ -189,10 +189,13 @@ func autoConvert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in *ListOptions
 	// FIXME: Provide conversion function to convert v1.ListOptions to internalversion.ListOptions
 	compileErrorOnMissingConversion()
 	// WARNING: in.Names requires manual conversion: inconvertible types (string vs []string)
-	out.Owner = in.Owner
 	// WARNING: in.ClusterNames requires manual conversion: inconvertible types (string vs []string)
 	// WARNING: in.Namespaces requires manual conversion: inconvertible types (string vs []string)
 	// WARNING: in.OrderBy requires manual conversion: inconvertible types (string vs []github.com/clusterpedia-io/clusterpedia/pkg/apis/clusterpedia.OrderBy)
+	out.OwnerUID = in.OwnerUID
+	out.OwnerName = in.OwnerName
+	// WARNING: in.OwnerGroupResource requires manual conversion: inconvertible types (string vs k8s.io/apimachinery/pkg/runtime/schema.GroupResource)
+	out.OwnerSeniority = in.OwnerSeniority
 	out.WithContinue = (*bool)(unsafe.Pointer(in.WithContinue))
 	out.WithRemainingCount = (*bool)(unsafe.Pointer(in.WithRemainingCount))
 	return nil
@@ -204,7 +207,6 @@ func autoConvert_clusterpedia_ListOptions_To_v1beta1_ListOptions(in *clusterpedi
 	if err := runtime.Convert_Slice_string_To_string(&in.Names, &out.Names, s); err != nil {
 		return err
 	}
-	out.Owner = in.Owner
 	if err := runtime.Convert_Slice_string_To_string(&in.ClusterNames, &out.ClusterNames, s); err != nil {
 		return err
 	}
@@ -212,6 +214,10 @@ func autoConvert_clusterpedia_ListOptions_To_v1beta1_ListOptions(in *clusterpedi
 		return err
 	}
 	// WARNING: in.OrderBy requires manual conversion: inconvertible types ([]github.com/clusterpedia-io/clusterpedia/pkg/apis/clusterpedia.OrderBy vs string)
+	out.OwnerName = in.OwnerName
+	out.OwnerUID = in.OwnerUID
+	// WARNING: in.OwnerGroupResource requires manual conversion: inconvertible types (k8s.io/apimachinery/pkg/runtime/schema.GroupResource vs string)
+	out.OwnerSeniority = in.OwnerSeniority
 	out.WithContinue = (*bool)(unsafe.Pointer(in.WithContinue))
 	out.WithRemainingCount = (*bool)(unsafe.Pointer(in.WithRemainingCount))
 	// WARNING: in.EnhancedFieldSelector requires manual conversion: does not exist in peer-type
@@ -229,13 +235,6 @@ func autoConvert_url_Values_To_v1beta1_ListOptions(in *url.Values, out *ListOpti
 		}
 	} else {
 		out.Names = ""
-	}
-	if values, ok := map[string][]string(*in)["owner"]; ok && len(values) > 0 {
-		if err := runtime.Convert_Slice_string_To_string(&values, &out.Owner, s); err != nil {
-			return err
-		}
-	} else {
-		out.Owner = ""
 	}
 	if values, ok := map[string][]string(*in)["clusters"]; ok && len(values) > 0 {
 		if err := runtime.Convert_Slice_string_To_string(&values, &out.ClusterNames, s); err != nil {
@@ -257,6 +256,34 @@ func autoConvert_url_Values_To_v1beta1_ListOptions(in *url.Values, out *ListOpti
 		}
 	} else {
 		out.OrderBy = ""
+	}
+	if values, ok := map[string][]string(*in)["ownerUID"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_string(&values, &out.OwnerUID, s); err != nil {
+			return err
+		}
+	} else {
+		out.OwnerUID = ""
+	}
+	if values, ok := map[string][]string(*in)["ownerName"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_string(&values, &out.OwnerName, s); err != nil {
+			return err
+		}
+	} else {
+		out.OwnerName = ""
+	}
+	if values, ok := map[string][]string(*in)["ownerGR"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_string(&values, &out.OwnerGroupResource, s); err != nil {
+			return err
+		}
+	} else {
+		out.OwnerGroupResource = ""
+	}
+	if values, ok := map[string][]string(*in)["ownerSeniority"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_int(&values, &out.OwnerSeniority, s); err != nil {
+			return err
+		}
+	} else {
+		out.OwnerSeniority = 0
 	}
 	if values, ok := map[string][]string(*in)["withContinue"]; ok && len(values) > 0 {
 		if err := runtime.Convert_Slice_string_To_Pointer_bool(&values, &out.WithContinue, s); err != nil {

--- a/pkg/apis/clusterpedia/zz_generated.deepcopy.go
+++ b/pkg/apis/clusterpedia/zz_generated.deepcopy.go
@@ -123,6 +123,7 @@ func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 		*out = make([]OrderBy, len(*in))
 		copy(*out, *in)
 	}
+	out.OwnerGroupResource = in.OwnerGroupResource
 	if in.WithContinue != nil {
 		in, out := &in.WithContinue, &out.WithContinue
 		*out = new(bool)

--- a/pkg/kubeapiserver/resourcerest/storage.go
+++ b/pkg/kubeapiserver/resourcerest/storage.go
@@ -66,9 +66,6 @@ func (s *RESTStorage) List(ctx context.Context, _ *metainternalversion.ListOptio
 	if err := scheme.ParameterCodec.DecodeParameters(query, v1beta1.SchemeGroupVersion, &opts); err != nil {
 		return nil, apierrors.NewBadRequest(err.Error())
 	}
-
-	// TODO(iceber): validate *internal.ListOptions
-
 	return s.list(ctx, &opts)
 }
 
@@ -84,6 +81,10 @@ func (s *RESTStorage) list(ctx context.Context, options *internal.ListOptions) (
 
 	if cluster := request.ClusterNameValue(ctx); cluster != "" {
 		options.ClusterNames = []string{cluster}
+	}
+
+	if (options.OwnerUID != "" || options.OwnerName != "") && len(options.ClusterNames) != 1 {
+		return nil, apierrors.NewBadRequest("If searching by owner uid or name, then the cluster must be specified")
 	}
 
 	/*


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

resolve: https://github.com/clusterpedia-io/clusterpedia/issues/49

Support searching resources by owner's groupresource and name.
|desc|search label|url query|
|----|----|---|
|Set owner's group and resource|`search.clusterpedia.io/owner-gr`=deployments.apps|ownerGR|
|Set owner's name|`search.clusterpedia.io/owner-name`=deploy1|ownerName|

If both `owner'uid` and `owner'name` are set, the `owner uid` will be the master and the `owner'group resource` will be ignored.