### PR TITLE
internalstorage: fix get resource

### DIFF
--- a/pkg/storage/internalstorage/resource_storage.go
+++ b/pkg/storage/internalstorage/resource_storage.go
@@ -135,20 +135,20 @@ func (s *ResourceStorage) Delete(ctx context.Context, cluster string, obj runtim
 }
 
 func (s *ResourceStorage) Get(ctx context.Context, cluster, namespace, name string, into runtime.Object) error {
-	var object []byte
-	result := s.db.WithContext(ctx).Select("object").Where(map[string]interface{}{
+	var objects [][]byte
+	result := s.db.WithContext(ctx).Model(&Resource{}).Select("object").Where(map[string]interface{}{
 		"cluster":   cluster,
 		"group":     s.storageGroupResource.Group,
 		"version":   s.storageVersion.Version,
 		"resource":  s.storageGroupResource.Resource,
 		"namespace": namespace,
 		"name":      name,
-	}).First(&object)
+	}).First(&objects)
 	if result.Error != nil {
 		return InterpreResourceError(cluster, namespace+"/"+name, result.Error)
 	}
 
-	obj, _, err := s.codec.Decode(object, nil, into)
+	obj, _, err := s.codec.Decode(objects[0], nil, into)
 	if err != nil {
 		return InterpreResourceError(cluster, namespace+"/"+name, err)
 	}


### PR DESCRIPTION
```bash
$ kubectl --cluster pedia get pods quickstart-ingress-nginx-admission-create--1-kxlnn
Error from server (InternalError): Internal error occurred: unsupported data type: &[]: Table not set, please set it like: db.Model(&user) or db.Table("users")
```

If only `db.Model(&Resource{})`, the error will be as follows:
```bash
$ kubectl --cluster pedia get pods quickstart-ingress-nginx-admission-create--1-kxlnn
Error from server (InternalError): Internal error occurred: sql: Scan error on column index 0, name "object": converting driver.Value type []uint8 ("{\"kind\": \"Pod\", \"spec\": {\"volumes\": [{\"name\": \"kube-api-access-xjxtg\", \"projected\": {\"sources\": [{\"serviceAccountToken\": {\"path\": \"token\", \"expirationSeconds\": 3607}}, {\"configMap\": {\"name\": \"kube-root-ca.crt\", \"items\": [{\"key\": \"ca.crt\", \"path\": \"ca.crt\"}]}}, {\"downwardAPI\": {\"items\": [{\"path\": \"namespace\", \"fieldRef\": {\"fieldPath\": \"metadata.namespace\", \"apiVersion\": \"v1\"}}]}}], \"defaultMode\": 420}}], \"nodeName\": \"caiwei-master\", \"priority\": 0, \"dnsPolicy\": \"ClusterFirst\", \"containers\": [{\"env\": [{\"name\": \"POD_NAMESPACE\", \"valueFrom\": {\"fieldRef\": {\"fieldPath\": \"metadata.namespace\", \"apiVersion\": \"v1\"}}}], \"args\": [\"create\", \"--host=quickstart-ingress-nginx-controller-admission,quickstart-ingress-nginx-controller-admission.$(POD_NAMESPACE).svc\", \"--namespace=$(POD_NAMESPACE)\", \"--secret-name=quickstart-ingress-nginx-admission\"], \"name\": \"create\", \"image\": \"k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068\", \"resources\": {}, \"volumeMounts\": [{\"name\": \"kube-api-access-xjxtg\", \"readOnly\": true, \"mountPath\": \"/var/run/secrets/kubernetes.io/serviceaccount\"}], \"imagePullPolicy\": \"IfNotPresent\", \"terminationMessagePath\": \"/dev/termination-log\", \"terminationMessagePolicy\": \"File\"}], \"tolerations\": [{\"key\": \"node.kubernetes.io/not-ready\", \"effect\": \"NoExecute\", \"operator\": \"Exists\", \"tolerationSeconds\": 300}, {\"key\": \"node.kubernetes.io/unreachable\", \"effect\": \"NoExecute\", \"operator\": \"Exists\", \"tolerationSeconds\": 300}], \"nodeSelector\": {\"kubernetes.io/os\": \"linux\"}, \"restartPolicy\": \"OnFailure\", \"schedulerName\": \"default-scheduler\", \"serviceAccount\": \"quickstart-ingress-nginx-admission\", \"securityContext\": {\"runAsUser\": 2000, \"runAsNonRoot\": true}, \"preemptionPolicy\": \"PreemptLowerPriority\", \"enableServiceLinks\": true, \"serviceAccountName\": \"quickstart-ingress-nginx-admission\", \"terminationGracePeriodSeconds\": 30}, \"status\": {\"phase\": \"Succeeded\", \"hostIP\": \"10.6.100.10\", \"qosClass\": \"BestEffort\", \"startTime\": \"2021-10-18T11:12:58Z\", \"conditions\": [{\"type\": \"Initialized\", \"reason\": \"PodCompleted\", \"status\": \"True\", \"lastProbeTime\": null, \"lastTransitionTime\": \"2021-10-18T11:12:58Z\"}, {\"type\": \"Ready\", \"reason\": \"PodCompleted\", \"status\": \"False\", \"lastProbeTime\": null, \"lastTransitionTime\": \"2021-10-18T11:12:58Z\"}, {\"type\": \"ContainersReady\", \"reason\": \"PodCompleted\", \"status\": \"False\", \"lastProbeTime\": null, \"lastTransitionTime\": \"2021-10-18T11:12:58Z\"}, {\"type\": \"PodScheduled\", \"status\": \"True\", \"lastProbeTime\": null, \"lastTransitionTime\": \"2021-10-18T11:12:58Z\"}], \"containerStatuses\": [{\"name\": \"create\", \"image\": \"sha256:17e55ec30f203e6acb1e2d35bf8af5e171b3734539e1d2b560c8e80f6b1b259a\", \"ready\": false, \"state\": {\"terminated\": {\"reason\": \"Completed\", \"exitCode\": 0, \"startedAt\": \"2021-11-17T15:17:30Z\", \"finishedAt\": \"2021-11-17T15:17:30Z\", \"containerID\": \"containerd://b5d36cf9a8eed1fa04d0de52a7a7696d4b52e4e45e42e9a968450219804115cd\"}}, \"imageID\": \"k8s.gcr.io/ingress-nginx/kube-webhook-certgen@sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068\", \"started\": false, \"lastState\": {}, \"containerID\": \"containerd://b5d36cf9a8eed1fa04d0de52a7a7696d4b52e4e45e42e9a968450219804115cd\", \"restartCount\": 0}]}, \"metadata\": {\"uid\": \"8ae7b142-ea14-4e5e-97d2-f9b0dea9bc5a\", \"name\": \"quickstart-ingress-nginx-admission-create--1-kxlnn\", \"labels\": {\"job-name\": \"quickstart-ingress-nginx-admission-create\", \"helm.sh/chart\": \"ingress-nginx-4.0.2\", \"controller-uid\": \"82264c6a-cdb4-4fa3-b301-a8b1d0dd9dda\", \"app.kubernetes.io/name\": \"ingress-nginx\", \"app.kubernetes.io/version\": \"1.0.1\", \"app.kubernetes.io/instance\": \"quickstart\", \"app.kubernetes.io/component\": \"admission-webhook\", \"app.kubernetes.io/managed-by\": \"Helm\"}, \"namespace\": \"default\", \"annotations\": {\"cni.projectcalico.org/podIP\": \"\", \"cni.projectcalico.org/podIPs\": \"\", \"cni.projectcalico.org/containerID\": \"32af29e02470e3e122dad7339d197c23688594bc34f005116a98ba78993bb547\", \"shadow.clusterpedia.io/cluster-name\": \"cluster-1\"}, \"generateName\": \"quickstart-ingress-nginx-admission-create--1-\", \"ownerReferences\": [{\"uid\": \"82264c6a-cdb4-4fa3-b301-a8b1d0dd9dda\", \"kind\": \"Job\", \"name\": \"quickstart-ingress-nginx-admission-create\", \"apiVersion\": \"batch/v1\", \"controller\": true, \"blockOwnerDeletion\": true}], \"resourceVersion\": \"37377239\", \"creationTimestamp\": \"2021-10-18T11:12:58Z\"}, \"apiVersion\": \"v1\"}") to a uint8: invalid syntax
```

fix: https://github.com/clusterpedia-io/clusterpedia/pull/89