### PR TITLE
clustersynchro: allow syncing of all custom resources 

### DIFF
--- a/charts/_crds/cluster.clusterpedia.io_pediaclusters.yaml
+++ b/charts/_crds/cluster.clusterpedia.io_pediaclusters.yaml
@@ -58,6 +58,8 @@ spec:
               kubeconfig:
                 format: byte
                 type: string
+              syncAllCustomResources:
+                type: boolean
               syncResources:
                 items:
                   properties:

--- a/pkg/synchromanager/clustersynchro/cluster_synchro.go
+++ b/pkg/synchromanager/clustersynchro/cluster_synchro.go
@@ -222,8 +222,9 @@ func (s *ClusterSynchro) Shutdown(updateReadyCondition, waitResourceSynchro bool
 	<-s.closed
 }
 
-func (s *ClusterSynchro) SetResources(syncResources []clusterv1alpha2.ClusterGroupResources) {
+func (s *ClusterSynchro) SetResources(syncResources []clusterv1alpha2.ClusterGroupResources, syncAllCustomResources bool) {
 	s.syncResources.Store(syncResources)
+	s.customResourceController.SetSyncAllCustomResources(syncAllCustomResources)
 	s.resetSyncResources()
 }
 

--- a/pkg/synchromanager/clustersynchro/resource_negotiator.go
+++ b/pkg/synchromanager/clustersynchro/resource_negotiator.go
@@ -38,6 +38,7 @@ func (negotiator *ResourceNegotiator) NegotiateSyncResources(syncResources []clu
 	var groupResourceStatus = NewGroupResourceStatus()
 	var storageResourceSyncConfigs = make(map[schema.GroupVersionResource]syncConfig)
 
+	syncResources = negotiator.customResourceController.HandleSyncResources(syncResources)
 	for _, groupResources := range syncResources {
 		for _, resource := range groupResources.Resources {
 			syncGR := schema.GroupResource{Group: groupResources.Group, Resource: resource}

--- a/pkg/synchromanager/clustersynchro_manager.go
+++ b/pkg/synchromanager/clustersynchro_manager.go
@@ -257,7 +257,7 @@ func (manager *Manager) reconcileCluster(cluster *clusterv1alpha2.PediaCluster) 
 		manager.synchroWaitGroup.StartWithChannel(manager.stopCh, synchro.Run)
 	}
 
-	synchro.SetResources(cluster.Spec.SyncResources)
+	synchro.SetResources(cluster.Spec.SyncResources, cluster.Spec.SyncAllCustomResources)
 
 	manager.synchrolock.Lock()
 	manager.synchros[cluster.Name] = synchro

--- a/pkg/synchromanager/features/features.go
+++ b/pkg/synchromanager/features/features.go
@@ -26,6 +26,12 @@ const (
 	// owner: @iceber
 	// alpha: v0.0.9
 	PruneLastAppliedConfiguration featuregate.Feature = "PruneLastAppliedConfiguration"
+
+	// AllowSyncAllCustomResources is a feature gate for the ClusterSynchro to allow syncing of all custom resources
+	//
+	// owner: @iceber
+	// alpha: v0.3.0
+	AllowSyncAllCustomResources featuregate.Feature = "AllowSyncAllCustomResources"
 )
 
 func init() {
@@ -37,4 +43,5 @@ func init() {
 var defaultClusterSynchroManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	PruneManagedFields:            {Default: false, PreRelease: featuregate.Alpha},
 	PruneLastAppliedConfiguration: {Default: false, PreRelease: featuregate.Alpha},
+	AllowSyncAllCustomResources:   {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
@@ -54,6 +54,9 @@ type ClusterSpec struct {
 
 	// +required
 	SyncResources []ClusterGroupResources `json:"syncResources"`
+
+	// +optional
+	SyncAllCustomResources bool `json:"syncAllCustomResources,omitempty"`
 }
 
 type ClusterGroupResources struct {


### PR DESCRIPTION
resolve: https://github.com/clusterpedia-io/clusterpedia/issues/111

**When synchronising custom resource resources at the same time, the custom resource will be connected twice, so consider reusing it in the future.**


`SyncAllCustomResources` is provided as an experimental feature and needs to be turned on in feature gates - `--feature-gates AllowSyncAllCustomResources=true`

The number of `custom resource definitions` is uncontrollable and may be very large, so if you encounter any exceptions or problems while synchronizing, please provide feedback in the issue in a timely manner