### PR TITLE
Supports remaincount as a negative number

### DIFF
--- a/pkg/storage/internalstorage/resource_storage.go
+++ b/pkg/storage/internalstorage/resource_storage.go
@@ -182,10 +182,9 @@ func (s *ResourceStorage) List(ctx context.Context, listObject runtime.Object, o
 	}
 
 	if amount != nil {
+		// When offset is too large, the data in the response is empty and the remaining count is negative.
+		// This ensures that `amount = offset + len(objects) + remain`
 		remain := *amount - offset - int64(len(objects))
-		if remain < 0 {
-			remain = 0
-		}
 		list.SetRemainingItemCount(&remain)
 	}
 


### PR DESCRIPTION
In use, if the offset used is too large, there is no data in the query. The returned remain count is 0, which will make the front-end paging unusable.Supporting remain count as a negative number for paging.