### PR TITLE
add ClusterSynchroInitialized status condition

### DIFF
--- a/pkg/kubeapiserver/resource_handler.go
+++ b/pkg/kubeapiserver/resource_handler.go
@@ -85,7 +85,7 @@ func (r *ResourceHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 
 		var msg string
-		readyCondition := meta.FindStatusCondition(cluster.Status.Conditions, clusterv1alpha2.ClusterConditionReady)
+		readyCondition := meta.FindStatusCondition(cluster.Status.Conditions, clusterv1alpha2.ClusterReadyCondition)
 		switch {
 		case readyCondition == nil:
 			msg = fmt.Sprintf("%s is not ready and the resources obtained may be inaccurate.", clusterName)

--- a/pkg/synchromanager/clustersynchro/cluster_monitor.go
+++ b/pkg/synchromanager/clustersynchro/cluster_monitor.go
@@ -30,7 +30,7 @@ func (synchro *ClusterSynchro) checkClusterHealthy() {
 		}
 
 		condition := metav1.Condition{
-			Type:    clusterv1alpha2.ClusterConditionReady,
+			Type:    clusterv1alpha2.ClusterReadyCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  "Unhealthy",
 			Message: "cluster health responded without ok",
@@ -54,7 +54,7 @@ func (synchro *ClusterSynchro) checkClusterHealthy() {
 	}
 
 	condition := metav1.Condition{
-		Type:               clusterv1alpha2.ClusterConditionReady,
+		Type:               clusterv1alpha2.ClusterReadyCondition,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Healthy",
 		LastTransitionTime: metav1.Now().Rfc3339Copy(),

--- a/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
@@ -6,12 +6,17 @@ import (
 )
 
 const (
-	ClusterConditionReady = "Ready"
+	ClusterReadyCondition   = "Ready"
+	ClusterSynchroCondition = "ClusterSynchroInitialized"
 
 	SyncStatusPending = "Pending"
 	SyncStatusSyncing = "Syncing"
 	SyncStatusStop    = "Stop"
 	SyncStatusUnknown = "Unknown"
+
+	InvalidConfigConditionReason = "InvalidConfig"
+	InitialFailedConditionReason = "InitialFailed"
+	RunningConditionReason       = "Running"
 )
 
 // +genclient

--- a/vendor/k8s.io/client-go/util/retry/OWNERS
+++ b/vendor/k8s.io/client-go/util/retry/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- caesarxuchao

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// OnError allows the caller to retry fn in case the error returned by fn is retriable
+// according to the provided function. backoff defines the maximum retries and the wait
+// interval between two retries.
+func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case retriable(err):
+			lastErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}
+
+// RetryOnConflict is used to make an update to a resource when you have to worry about
+// conflicts caused by other code making unrelated updates to the resource at the same
+// time. fn should fetch the resource to be modified, make appropriate changes to it, try
+// to update it, and return (unmodified) the error from the update function. On a
+// successful update, RetryOnConflict will return nil. If the update function returns a
+// "Conflict" error, RetryOnConflict will wait some amount of time as described by
+// backoff, and then try again. On a non-"Conflict" error, or if it retries too many times
+// and gives up, RetryOnConflict will return an error to the caller.
+//
+//     err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+//         // Fetch the resource here; you need to refetch it on every try, since
+//         // if you got a conflict on the last update attempt then you need to get
+//         // the current version before making your own changes.
+//         pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
+//         if err ! nil {
+//             return err
+//         }
+//
+//         // Make whatever updates to the resource are needed
+//         pod.Status.Phase = v1.PodFailed
+//
+//         // Try to update
+//         _, err = c.Pods("mynamespace").UpdateStatus(pod)
+//         // You have to return err itself here (not wrapped inside another error)
+//         // so that RetryOnConflict can identify it correctly.
+//         return err
+//     })
+//     if err != nil {
+//         // May be conflict if max retries were hit, or may be something unrelated
+//         // like permissions or a network error
+//         return err
+//     }
+//     ...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	return OnError(backoff, errors.IsConflict, fn)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -935,6 +935,7 @@ k8s.io/client-go/util/connrotation
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
+k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/code-generator v0.22.2 => github.com/k3s-io/kubernetes/staging/src/k8s.io/code-generator v1.22.4-k3s1
 ## explicit


### PR DESCRIPTION
The plan to fix this issue:
1, Add one type condition: ClusterSynchro. The ClusterSynchro condition has two status: True/False and three reason: InvalidConfig/InitialFailed/Running corresponding to buildClusterConfig/New/Run progress.
2, If cluster config changed, shutdown the synchro, change the Ready contion to Unkown status with reason ClusterSynchroStop, and set the cluster synchro to nil in the manager's synchros map. 
3, If the new progress failed, change the ClusterSynchro condition to False status with reason InitialFailed, with message of the error.
4, After call the synchro run, change the ClusterSynchro condition to True status with reason Running.

#8 