### PR TITLE
add synced state for synchromanager

### DIFF
--- a/pkg/synchromanager/clustersynchro/queue/pressurequeue.go
+++ b/pkg/synchromanager/clustersynchro/queue/pressurequeue.go
@@ -98,10 +98,10 @@ func (q *pressurequeue) put(key string, event *Event) {
 	q.cond.Broadcast()
 }
 
-func (q *pressurequeue) Done(event *Event) error {
+func (q *pressurequeue) Done(event *Event) (bool, error) {
 	key, err := q.keyFunc(event.Object)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	q.lock.Lock()
@@ -112,7 +112,7 @@ func (q *pressurequeue) Done(event *Event) error {
 		q.queue = append(q.queue, key)
 	}
 	q.cond.Broadcast()
-	return nil
+	return len(q.items) == 0 && len(q.processing) == 0, nil
 }
 
 func (q *pressurequeue) Pop() (*Event, error) {

--- a/pkg/synchromanager/clustersynchro/queue/queue.go
+++ b/pkg/synchromanager/clustersynchro/queue/queue.go
@@ -10,7 +10,7 @@ type EventQueue interface {
 	Delete(obj interface{}) error
 
 	Pop() (*Event, error)
-	Done(event *Event) error
+	Done(event *Event) (bool, error)
 
 	Close()
 }

--- a/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
@@ -9,11 +9,6 @@ const (
 	ClusterReadyCondition   = "Ready"
 	ClusterSynchroCondition = "ClusterSynchroInitialized"
 
-	SyncStatusPending = "Pending"
-	SyncStatusSyncing = "Syncing"
-	SyncStatusStop    = "Stop"
-	SyncStatusUnknown = "Unknown"
-
 	InvalidConfigConditionReason = "InvalidConfig"
 	InitialFailedConditionReason = "InitialFailed"
 	RunningConditionReason       = "Running"
@@ -23,6 +18,14 @@ const (
 	UnhealthyReason          = "Unhealthy"
 	NotReachableReason       = "NotReachable"
 	ClusterSynchroStopReason = "ClusterSynchroStop"
+	ClusterConditionReady = "Ready"
+	
+	SyncStatusStart       = "Start"
+	SyncStatusPending     = "Pending"
+	SyncStatusSyncing     = "Syncing"
+	SyncStatusSynced      = "Synced"
+	SyncStatusStop        = "Stop"
+	SyncStatusUnknown     = "Unknown"
 )
 
 // +genclient


### PR DESCRIPTION
add `synced` and `start` state.

`start` indicates the phase in which resources are prepared synchronously.
`synced` indicates when all the resources have been synchronized.
