### PR TITLE
update the methods for resource synchro

### DIFF
--- a/pkg/synchromanager/clustersynchro_manager.go
+++ b/pkg/synchromanager/clustersynchro_manager.go
@@ -242,7 +242,7 @@ func (manager *Manager) reconcileCluster(cluster *clusterv1alpha2.PediaCluster) 
 	if synchro != nil && !reflect.DeepEqual(synchro.RESTConfig, config) {
 		klog.InfoS("cluster config is changed, rebuild cluster synchro", "cluster", cluster.Name)
 
-		synchro.Shutdown(true, false)
+		synchro.Shutdown(true)
 		synchro = nil
 
 		manager.synchrolock.Lock()
@@ -284,7 +284,7 @@ func (manager *Manager) removeCluster(name string) error {
 	if synchro != nil {
 		// not update removed cluster,
 		// and ensure that no more data is being synchronized to the resource storage
-		synchro.Shutdown(false, true)
+		synchro.Shutdown(false)
 	}
 	return manager.cleanCluster(name)
 }


### PR DESCRIPTION
Change the method name of the resource synchro：
* `(*ResourceSynchro).Run(stopCh <- chan struct{})` -> `(*ResourceSynchro).Start(stopCh <- chan struct{})`
* `(*ResourceSynchro).runStorager(shutdown <- chan struct{})` -> `(*ResourceSynchro).Run(shutdown <- chan struct{})`

Wait for all resource synchros to stop when shutting down the cluster synchro