### PR TITLE
support raw sql query

### DIFF
--- a/pkg/storage/internalstorage/features.go
+++ b/pkg/storage/internalstorage/features.go
@@ -1,0 +1,25 @@
+package internalstorage
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// AllowRawSQLQuery is a feature gate for the apiserver to allow querying by the raw sql.
+	//
+	// owner: @cleverhu
+	// alpha: v0.3.0
+	AllowRawSQLQuery featuregate.Feature = "AllowRawSQLQuery"
+)
+
+func init() {
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultInternalStorageFeatureGates))
+}
+
+// defaultInternalStorageFeatureGates consists of all known custom internalstorage feature keys.
+// To add a new feature, define a key for it above and add it here.
+var defaultInternalStorageFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	AllowRawSQLQuery: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/types.go
@@ -68,7 +68,7 @@ type ListOptions struct {
 	ExtraLabelSelector labels.Selector
 
 	// +k8s:conversion-fn:drop
-	ExtraQuery url.Values
+	URLQuery url.Values
 
 	// RelatedResources []schema.GroupVersionKind
 }

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion.go
@@ -183,6 +183,10 @@ func Convert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in *ListOptions, ou
 	if out.Before.Before(out.Since) {
 		return fmt.Errorf("Invalid Query, Since is after Before")
 	}
+	if len(in.urlQuery) > 0 {
+		// Out URLQuery will not be modified, so deepcopy is not used here.
+		out.URLQuery = in.urlQuery
+	}
 	return nil
 }
 
@@ -229,6 +233,8 @@ func Convert_url_Values_To_v1beta1_ListOptions(in *url.Values, out *ListOptions,
 	if err := metav1.Convert_url_Values_To_v1_ListOptions(in, &out.ListOptions, s); err != nil {
 		return err
 	}
+	// Save the native query parameters for use by listoptions.
+	out.urlQuery = *in
 
 	return autoConvert_url_Values_To_v1beta1_ListOptions(in, out, s)
 }

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/types.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"net/url"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -46,6 +48,8 @@ type ListOptions struct {
 
 	// +optional
 	WithRemainingCount *bool `json:"withRemainingCount,omitempty"`
+
+	urlQuery url.Values
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/zz_generated.conversion.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/zz_generated.conversion.go
@@ -201,6 +201,7 @@ func autoConvert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in *ListOptions
 	out.OwnerSeniority = in.OwnerSeniority
 	out.WithContinue = (*bool)(unsafe.Pointer(in.WithContinue))
 	out.WithRemainingCount = (*bool)(unsafe.Pointer(in.WithRemainingCount))
+	// WARNING: in.urlQuery requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -227,7 +228,7 @@ func autoConvert_clusterpedia_ListOptions_To_v1beta1_ListOptions(in *clusterpedi
 	out.WithRemainingCount = (*bool)(unsafe.Pointer(in.WithRemainingCount))
 	// WARNING: in.EnhancedFieldSelector requires manual conversion: does not exist in peer-type
 	// WARNING: in.ExtraLabelSelector requires manual conversion: does not exist in peer-type
-	// WARNING: in.ExtraQuery requires manual conversion: does not exist in peer-type
+	// WARNING: in.URLQuery requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -318,5 +319,7 @@ func autoConvert_url_Values_To_v1beta1_ListOptions(in *url.Values, out *ListOpti
 	} else {
 		out.WithRemainingCount = nil
 	}
+	// WARNING: Field urlQuery does not have json tag, skipping.
+
 	return nil
 }

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/zz_generated.deepcopy.go
@@ -6,6 +6,8 @@
 package v1beta1
 
 import (
+	url "net/url"
+
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -109,6 +111,21 @@ func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 		in, out := &in.WithRemainingCount, &out.WithRemainingCount
 		*out = new(bool)
 		**out = **in
+	}
+	if in.urlQuery != nil {
+		in, out := &in.urlQuery, &out.urlQuery
+		*out = make(url.Values, len(*in))
+		for key, val := range *in {
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
+		}
 	}
 	return
 }

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/zz_generated.deepcopy.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/zz_generated.deepcopy.go
@@ -149,8 +149,8 @@ func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 	if in.ExtraLabelSelector != nil {
 		out.ExtraLabelSelector = in.ExtraLabelSelector.DeepCopySelector()
 	}
-	if in.ExtraQuery != nil {
-		in, out := &in.ExtraQuery, &out.ExtraQuery
+	if in.URLQuery != nil {
+		in, out := &in.URLQuery, &out.URLQuery
 		*out = make(url.Values, len(*in))
 		for key, val := range *in {
 			var outVal []string


### PR DESCRIPTION
Support raw sql by query path and add feature-gate for it。

How to use:
First: Add ` --feature-gates=AllowRawSQLQuery=true` args for apiserver deployment to open the feature-gate.

Second:
Use kubectl:
`kubectl get --raw="/apis/clusterpedia.io/v1beta1/resources/apis/apps/v1/namespaces/default/deployments?limit=5&whereSQL=(namespace='default') or (name like '%25b%25')"`
tips:
%25 is the % after encode
or use clusterpedia client-go.
<img width="549" alt="image" src="https://user-images.githubusercontent.com/51436614/166922386-dc9364d5-6ee9-466a-ab50-dbcdfd709b56.png">
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/51436614/167059889-ee5afc71-bf2c-430d-bf46-58f706959691.png">

Known problems:
1、Preventing SQL injection is needed to be done.
2、If and incorrect SQL statement is passed in. If it is a number, ID will be used as the query condition by default.
If it contains English letter, it will be passed in as column.
such as:
A number is passed in:
<img width="1074" alt="wecom-temp-e15867c7cedc1bca0a5fde21dc48d226" src="https://user-images.githubusercontent.com/51436614/167060120-8d1d200f-84af-466c-9ece-28b8c67ed54c.png">
English letter is passed in:
<img width="1037" alt="wecom-temp-8509c799f282d1b2ca439ea0f794d9bb" src="https://user-images.githubusercontent.com/51436614/167060165-398e1a3b-0e44-445e-b74c-6b4bca58cbe4.png">



