### PR TITLE
fix reload restmapper when crd deleted

### DIFF
--- a/pkg/synchromanager/clustersynchro/cluster_synchro.go
+++ b/pkg/synchromanager/clustersynchro/cluster_synchro.go
@@ -121,7 +121,7 @@ func New(name string, config *rest.Config, storage storage.StorageFactory, updat
 	}
 	synchro.version.Store(*version)
 
-	customResourceController, err := NewCustomResourceController(name, config, crdGVRs[0].Version)
+	customResourceController, err := NewCustomResourceController(name, config, crdGVRs[0].Version, mapper)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add restmapper in CustomResourceController, when a CRD resource is been deleted, trigger to reload the cluster restermapper by  querying a never exists resource version. The dynamicRESTMapper method checkAndReload will reload the mapper at the backend.

@Iceber PTAL, thanks.

#6 