### PR TITLE
[BUG] - External Database Password

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Return the proper Docker Image Registry Secret Names
 
 {{- define "clusterpedia.storage.password" -}}
 {{- if eq .Values.storageInstallMode "external" }}
-     {{- required "Please set correct storage password!" .Values.externalStorage.password -}}
+     {{- required "Please set correct storage password!" .Values.externalStorage.password | b64enc -}}
 {{- else -}}
      {{- if eq (include "clusterpedia.storage.type" .) "postgres" }}
           {{- if not (empty .Values.global.postgresql.auth.username) -}}


### PR DESCRIPTION
Note, I'm not sure if this is intentional so raising as a bug. The external password is not base64 encoded and so is copied direct into the secret. 

On a related issue, since I was considering to raise it - it would be nice to make the name `name` amd `key` configurable as it makes it eaiser to share between components and potentially supporting a DB_HOSTNAME for again easy templating. 

```YAML
- name: DB_PASSWORD
  valueFrom:
     secretKeyRef:
       name: {{ include "clusterpedia.internalstorage.fullname" . }}
       key: password
```