### PR TITLE
support set sync resources with wildcard

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -196,15 +196,22 @@ clustersynchroManager:
     ## alpha: v0.0.9
     ## beta: v0.3.0
     PruneManagedFields: true
+
     ## @param PruneLastAppliedConfiguration is a feature gate for the ClusterSynchro to prune `LastAppliedConfiguration` of the resource
     ## owner: @iceber
     ## alpha: v0.0.9
     ## beta: v0.3.0
     PruneLastAppliedConfiguration: true
+
     ## @param AllowSyncAllCustomResources is a feature gate for the ClusterSynchro to allow syncing of all custom resources
     ## owner: @iceber
     ## alpha: v0.3.0
     AllowSyncAllCustomResources: false
+
+    ## @param AllowSyncAllResources is a feature gate for the ClusterSynchro to allow syncing of all resources
+    ## owner: @iceber
+    ## alpha: v0.3.0
+    AllowSyncAllResources: false
 
 ## @section PostgreSQL Parameters
 ##

--- a/pkg/synchromanager/features/features.go
+++ b/pkg/synchromanager/features/features.go
@@ -34,6 +34,12 @@ const (
 	// owner: @iceber
 	// alpha: v0.3.0
 	AllowSyncAllCustomResources featuregate.Feature = "AllowSyncAllCustomResources"
+
+	// AllowSyncAllResources is a feature gate for the ClusterSynchro to allow syncing of all resources
+	//
+	// owner: @iceber
+	// alpha: v0.3.0
+	AllowSyncAllResources featuregate.Feature = "AllowSyncAllResources"
 )
 
 func init() {
@@ -46,4 +52,5 @@ var defaultClusterSynchroManagerFeatureGates = map[featuregate.Feature]featurega
 	PruneManagedFields:            {Default: true, PreRelease: featuregate.Beta},
 	PruneLastAppliedConfiguration: {Default: true, PreRelease: featuregate.Beta},
 	AllowSyncAllCustomResources:   {Default: false, PreRelease: featuregate.Alpha},
+	AllowSyncAllResources:         {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
@@ -15,9 +15,10 @@ const (
 	SyncStatusUnknown = "Unknown"
 	SyncStatusError   = "Error"
 
-	InvalidConfigConditionReason = "InvalidConfig"
-	InitialFailedConditionReason = "InitialFailed"
-	RunningConditionReason       = "Running"
+	InvalidConfigConditionReason       = "InvalidConfig"
+	InvalidSyncResourceConditionReason = "InvalidSyncResources"
+	InitialFailedConditionReason       = "InitialFailed"
+	RunningConditionReason             = "Running"
 
 	HealthyReason            = "Healthy"
 	PendingReason            = "Pending"


### PR DESCRIPTION
issue: https://github.com/clusterpedia-io/clusterpedia/issues/168

all-resource wildcards
```yaml
- group: "*"
   resources:
   - "*"
```
 group resource wildcards
```yaml
- group: "apps"
   resources:
   - "*"
```

Note:
The all-resource wildcard will generate many long connections, so if the user does not need to synchronize all resources, it is recommended to specify the type of resources or only synchronize custom resources https://github.com/clusterpedia-io/clusterpedia/pull/112.

And if you want to use all-resource wildcard, you need to enable feature gate `--feature-gates=AllowSyncAllResources=true`.