### PR TITLE
fix chart featureGate

### DIFF
--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -50,7 +50,7 @@ Return the proper Docker Image Registry Secret Names
      {{- if (not (empty .Values.apiserver.featureGates)) }}
           {{- $featureGatesFlag := "" -}}
           {{- range $key, $value := .Values.apiserver.featureGates -}}
-               {{- if $value }}
+               {{- if not (empty (toString $value)) }}
                     {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value "," -}}
                {{- end -}}
           {{- end -}}
@@ -66,7 +66,7 @@ Return the proper Docker Image Registry Secret Names
      {{- if (not (empty .Values.clustersynchroManager.featureGates)) }}
           {{- $featureGatesFlag := "" -}}
           {{- range $key, $value := .Values.clustersynchroManager.featureGates -}}
-               {{- if $value }}
+               {{- if not (empty (toString $value)) }}
                     {{- $featureGatesFlag = cat $featureGatesFlag $key "=" $value ","  -}}
                {{- end -}}
           {{- end -}}


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind bug

Fixed the  judge condition of featureGate value. 
The featureGate value set by `--set` may be a bool or a string.  only it's a empty string do we not to render the featureGate item to yaml template files.  if the value is false, it should alse be rendered to yaml files. 

wo should switch the bool value to string and judge its length.


