### PR TITLE
support to get only the metadata of collection resources 

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -138,6 +138,7 @@ func (config completedConfig) New() (*ClusterPediaServer, error) {
 	config.GenericConfig.BuildHandlerChainFunc = func(apiHandler http.Handler, c *genericapiserver.Config) http.Handler {
 		handler := handlerChainFunc(apiHandler, c)
 		handler = filters.WithRequestQuery(handler)
+		handler = filters.WithAcceptHeader(handler)
 		return handler
 	}
 
@@ -148,7 +149,7 @@ func (config completedConfig) New() (*ClusterPediaServer, error) {
 
 	v1beta1storage := map[string]rest.Storage{}
 	v1beta1storage["resources"] = resources.NewREST(kubeResourceAPIServer.Handler)
-	v1beta1storage["collectionresources"] = collectionresources.NewREST(config.StorageFactory)
+	v1beta1storage["collectionresources"] = collectionresources.NewREST(config.GenericConfig.Serializer, config.StorageFactory)
 
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(internal.GroupName, Scheme, ParameterCodec, Codecs)
 	apiGroupInfo.VersionedResourcesStorageMap["v1beta1"] = v1beta1storage

--- a/pkg/apiserver/registry/clusterpedia/collectionresources/negotiation.go
+++ b/pkg/apiserver/registry/clusterpedia/collectionresources/negotiation.go
@@ -1,0 +1,43 @@
+package collectionresources
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
+)
+
+var (
+	TableEndpointRestrictions   negotiation.EndpointRestrictions = defaultEndpointRestrictions{false}
+	DefaultEndpointRestrictions negotiation.EndpointRestrictions = defaultEndpointRestrictions{true}
+)
+
+type defaultEndpointRestrictions struct {
+	allowPartialObjectMetadata bool
+}
+
+func (r defaultEndpointRestrictions) AllowsMediaTypeTransform(mimeType, mimeSubType string, gvk *schema.GroupVersionKind) bool {
+	if gvk == nil {
+		return false
+	}
+
+	if gvk.GroupVersion() != metav1beta1.SchemeGroupVersion && gvk.GroupVersion() != metav1.SchemeGroupVersion {
+		return false
+	}
+
+	switch gvk.Kind {
+	case "Table":
+		return mimeType == "application" && (mimeSubType == "json" || mimeSubType == "yaml")
+	case "PartialObjectMetadata", "PartialObjectMetadataList":
+		return r.allowPartialObjectMetadata
+	}
+	return false
+}
+
+func (r defaultEndpointRestrictions) AllowsServerVersion(version string) bool {
+	return false
+}
+
+func (r defaultEndpointRestrictions) AllowsStreamSchema(s string) bool {
+	return s == "watch"
+}

--- a/pkg/storage/internalstorage/storage.go
+++ b/pkg/storage/internalstorage/storage.go
@@ -2,52 +2,14 @@ package internalstorage
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
-	"time"
 
-	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 
 	internal "github.com/clusterpedia-io/api/clusterpedia"
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
 )
-
-type Resource struct {
-	ID uint `gorm:"primaryKey"`
-
-	Group    string `gorm:"size:63;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name;index:idx_group_version_resource_namespace_name;index:idx_group_version_resource_name"`
-	Version  string `gorm:"size:15;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name;index:idx_group_version_resource_namespace_name;index:idx_group_version_resource_name"`
-	Resource string `gorm:"size:63;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name;index:idx_group_version_resource_namespace_name;index:idx_group_version_resource_name"`
-	Kind     string `gorm:"size:63;not null"`
-
-	Cluster         string    `gorm:"size:253;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name,length:100;index:idx_cluster"`
-	Namespace       string    `gorm:"size:253;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name,length:50;index:idx_group_version_resource_namespace_name"`
-	Name            string    `gorm:"size:253;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name,length:100;index:idx_group_version_resource_namespace_name;index:idx_group_version_resource_name"`
-	OwnerUID        types.UID `gorm:"column:owner_uid;size:36;not null;default:''"`
-	UID             types.UID `gorm:"size:36;not null"`
-	ResourceVersion string    `gorm:"size:30;not null"`
-
-	Object datatypes.JSON `gorm:"not null"`
-
-	CreatedAt time.Time `gorm:"not null"`
-	SyncedAt  time.Time `gorm:"not null;autoUpdateTime"`
-	DeletedAt sql.NullTime
-}
-
-// SelectedResource used to select specific fields
-type SelectedResource struct {
-}
-
-func (res Resource) GroupVersionResource() schema.GroupVersionResource {
-	return schema.GroupVersionResource{
-		Group:    res.Group,
-		Version:  res.Version,
-		Resource: res.Resource,
-	}
-}
 
 type StorageFactory struct {
 	db *gorm.DB

--- a/pkg/storage/internalstorage/types.go
+++ b/pkg/storage/internalstorage/types.go
@@ -1,0 +1,142 @@
+package internalstorage
+
+import (
+	"database/sql"
+	"time"
+
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type Resource struct {
+	ID uint `gorm:"primaryKey"`
+
+	Group    string `gorm:"size:63;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name;index:idx_group_version_resource_namespace_name;index:idx_group_version_resource_name"`
+	Version  string `gorm:"size:15;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name;index:idx_group_version_resource_namespace_name;index:idx_group_version_resource_name"`
+	Resource string `gorm:"size:63;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name;index:idx_group_version_resource_namespace_name;index:idx_group_version_resource_name"`
+	Kind     string `gorm:"size:63;not null"`
+
+	Cluster         string    `gorm:"size:253;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name,length:100;index:idx_cluster"`
+	Namespace       string    `gorm:"size:253;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name,length:50;index:idx_group_version_resource_namespace_name"`
+	Name            string    `gorm:"size:253;not null;uniqueIndex:uni_group_version_resource_cluster_namespace_name,length:100;index:idx_group_version_resource_namespace_name;index:idx_group_version_resource_name"`
+	OwnerUID        types.UID `gorm:"column:owner_uid;size:36;not null;default:''"`
+	UID             types.UID `gorm:"size:36;not null"`
+	ResourceVersion string    `gorm:"size:30;not null"`
+
+	Object datatypes.JSON `gorm:"not null"`
+
+	CreatedAt time.Time `gorm:"not null"`
+	SyncedAt  time.Time `gorm:"not null;autoUpdateTime"`
+	DeletedAt sql.NullTime
+}
+
+func (res Resource) GroupVersionResource() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    res.Group,
+		Version:  res.Version,
+		Resource: res.Resource,
+	}
+}
+
+type Object interface {
+	GetResourceType() ResourceType
+	ConvertToUnstructured() (*unstructured.Unstructured, error)
+}
+
+type ObjectList interface {
+	From(db *gorm.DB) error
+	Items() []Object
+}
+
+type ResourceType struct {
+	Group    string
+	Version  string
+	Resource string
+	Kind     string
+}
+
+func (res ResourceType) GroupVersionResource() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    res.Group,
+		Version:  res.Version,
+		Resource: res.Resource,
+	}
+}
+
+func (res Resource) GetResourceType() ResourceType {
+	return ResourceType{
+		Group:    res.Group,
+		Version:  res.Version,
+		Resource: res.Resource,
+		Kind:     res.Kind,
+	}
+}
+
+func (res Resource) ConvertToUnstructured() (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	if err := caseSensitiveJSONIterator.Unmarshal(res.Object, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+type ResourceList []Resource
+
+func (list *ResourceList) From(db *gorm.DB) error {
+	resources := []Resource{}
+	if result := db.Find(&resources); result.Error != nil {
+		return result.Error
+	}
+	*list = resources
+	return nil
+}
+
+func (list ResourceList) Items() []Object {
+	objects := make([]Object, 0, len(list))
+	for _, object := range list {
+		objects = append(objects, object)
+	}
+	return objects
+}
+
+type ResourceMetadata struct {
+	ResourceType `gorm:"embedded"`
+
+	Metadata datatypes.JSONMap
+}
+
+func (data ResourceMetadata) ConvertToUnstructured() (*unstructured.Unstructured, error) {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": schema.GroupVersion{Group: data.Group, Version: data.Version}.String(),
+			"kind":       data.Kind,
+			"metadata":   map[string]interface{}(data.Metadata),
+		},
+	}, nil
+}
+
+func (data ResourceMetadata) GetResourceType() ResourceType {
+	return data.ResourceType
+}
+
+type ResourceMetadataList []ResourceMetadata
+
+func (list *ResourceMetadataList) From(db *gorm.DB) error {
+	metadatas := []ResourceMetadata{}
+	if result := db.Find(&metadatas); result.Error != nil {
+		return result.Error
+	}
+	*list = metadatas
+	return nil
+}
+
+func (list ResourceMetadataList) Items() []Object {
+	objects := make([]Object, 0, len(list))
+	for _, object := range list {
+		objects = append(objects, object)
+	}
+	return objects
+}

--- a/pkg/utils/filters/accept.go
+++ b/pkg/utils/filters/accept.go
@@ -1,0 +1,14 @@
+package filters
+
+import (
+	"net/http"
+
+	"github.com/clusterpedia-io/clusterpedia/pkg/utils/request"
+)
+
+func WithAcceptHeader(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req = req.WithContext(request.WithAcceptHeader(req.Context(), req.Header.Get("Accept")))
+		handler.ServeHTTP(w, req)
+	})
+}

--- a/pkg/utils/request/header.go
+++ b/pkg/utils/request/header.go
@@ -1,0 +1,21 @@
+package request
+
+import (
+	"context"
+)
+
+type headerKeyType int
+
+const acceptHeaderKey headerKeyType = iota
+
+func WithAcceptHeader(parent context.Context, accept string) context.Context {
+	if accept == "" {
+		return parent
+	}
+	return context.WithValue(parent, acceptHeaderKey, accept)
+}
+
+func AcceptHeaderFrom(ctx context.Context) string {
+	query, _ := ctx.Value(acceptHeaderKey).(string)
+	return query
+}

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/types.go
@@ -71,6 +71,8 @@ type ListOptions struct {
 	URLQuery url.Values
 
 	// RelatedResources []schema.GroupVersionKind
+
+	OnlyMetadata bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion.go
@@ -187,6 +187,8 @@ func Convert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in *ListOptions, ou
 		// Out URLQuery will not be modified, so deepcopy is not used here.
 		out.URLQuery = in.urlQuery
 	}
+
+	out.OnlyMetadata = in.OnlyMetadata
 	return nil
 }
 

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/types.go
@@ -49,6 +49,9 @@ type ListOptions struct {
 	// +optional
 	WithRemainingCount *bool `json:"withRemainingCount,omitempty"`
 
+	// +optional
+	OnlyMetadata bool `json:"onlyMetadata,omitempty"`
+
 	urlQuery url.Values
 }
 

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/zz_generated.conversion.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/zz_generated.conversion.go
@@ -201,6 +201,7 @@ func autoConvert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in *ListOptions
 	out.OwnerSeniority = in.OwnerSeniority
 	out.WithContinue = (*bool)(unsafe.Pointer(in.WithContinue))
 	out.WithRemainingCount = (*bool)(unsafe.Pointer(in.WithRemainingCount))
+	out.OnlyMetadata = in.OnlyMetadata
 	// WARNING: in.urlQuery requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -229,6 +230,7 @@ func autoConvert_clusterpedia_ListOptions_To_v1beta1_ListOptions(in *clusterpedi
 	// WARNING: in.EnhancedFieldSelector requires manual conversion: does not exist in peer-type
 	// WARNING: in.ExtraLabelSelector requires manual conversion: does not exist in peer-type
 	// WARNING: in.URLQuery requires manual conversion: does not exist in peer-type
+	out.OnlyMetadata = in.OnlyMetadata
 	return nil
 }
 
@@ -318,6 +320,13 @@ func autoConvert_url_Values_To_v1beta1_ListOptions(in *url.Values, out *ListOpti
 		}
 	} else {
 		out.WithRemainingCount = nil
+	}
+	if values, ok := map[string][]string(*in)["onlyMetadata"]; ok && len(values) > 0 {
+		if err := runtime.Convert_Slice_string_To_bool(&values, &out.OnlyMetadata, s); err != nil {
+			return err
+		}
+	} else {
+		out.OnlyMetadata = false
 	}
 	// WARNING: Field urlQuery does not have json tag, skipping.
 


### PR DESCRIPTION
fix: https://github.com/clusterpedia-io/clusterpedia/issues/169

Use `kubectl get collectionresources [workloads|kuberesources]` or specify query (onlyMetadata) in the url to get only the metadata

```bash
$ kubectl get collectionresources kuberesources

$ kubectl get --raw "/apis/clusterpedia.io/v1beta1/collectionresources/kuberesources?onlyMetadata=true" 
```