### PR TITLE
fix collection resources order

### DIFF
--- a/pkg/storage/internalstorage/collectionresource.go
+++ b/pkg/storage/internalstorage/collectionresource.go
@@ -13,8 +13,8 @@ const (
 	CollectionResourceKubeResources = "kuberesources"
 )
 
-var collectionResources = map[string]internal.CollectionResource{
-	CollectionResourceWorkloads: {
+var collectionResources = []internal.CollectionResource{
+	{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: CollectionResourceWorkloads,
 		},
@@ -33,8 +33,7 @@ var collectionResources = map[string]internal.CollectionResource{
 			},
 		},
 	},
-
-	CollectionResourceKubeResources: {
+	{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: CollectionResourceKubeResources,
 		},
@@ -54,10 +53,9 @@ func init() {
 		})
 	}
 
-	collectionResources[CollectionResourceKubeResources] = internal.CollectionResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: CollectionResourceKubeResources,
-		},
-		ResourceTypes: types,
+	for i := range collectionResources {
+		if collectionResources[i].Name == CollectionResourceKubeResources {
+			collectionResources[i].ResourceTypes = types
+		}
 	}
 }

--- a/pkg/storage/internalstorage/storage.go
+++ b/pkg/storage/internalstorage/storage.go
@@ -27,10 +27,12 @@ func (s *StorageFactory) NewResourceStorage(config *storage.ResourceStorageConfi
 }
 
 func (s *StorageFactory) NewCollectionResourceStorage(cr *internal.CollectionResource) (storage.CollectionResourceStorage, error) {
-	if _, ok := collectionResources[cr.Name]; !ok {
-		return nil, fmt.Errorf("not support collection resource: %s", cr.Name)
+	for i := range collectionResources {
+		if collectionResources[i].Name == cr.Name {
+			return NewCollectionResourceStorage(s.db, cr), nil
+		}
 	}
-	return NewCollectionResourceStorage(s.db, cr), nil
+	return nil, fmt.Errorf("not support collection resource: %s", cr.Name)
 }
 
 func (f *StorageFactory) GetResourceVersions(ctx context.Context, cluster string) (map[schema.GroupVersionResource]map[string]interface{}, error) {


### PR DESCRIPTION
When the resource is a map, the order of `kubectl get collectionresource` cannot be guaranteed after the apiserver is restarted.