### PR TITLE
bug fix: os.exit will not wait for the defer function

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -11,12 +11,19 @@ import (
 )
 
 func main() {
+	if err := runApiServerCommand(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runApiServerCommand() error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
 	ctx := apiserver.SetupSignalContext()
 	if err := app.NewClusterPediaServerCommand(ctx).Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		return err
 	}
+	return nil
 }

--- a/cmd/clustersynchro-manager/main.go
+++ b/cmd/clustersynchro-manager/main.go
@@ -13,6 +13,13 @@ import (
 )
 
 func main() {
+	if err := runClusterSynchroManagerCommand(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runClusterSynchroManagerCommand() error {
 	rand.Seed(time.Now().UnixNano())
 
 	logs.InitLogs()
@@ -20,7 +27,8 @@ func main() {
 
 	ctx := apiserver.SetupSignalContext()
 	if err := app.NewClusterSynchroManagerCommand(ctx).Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }


### PR DESCRIPTION
FlushLogs()will not call if os.Exit(1)
referring to 
https://github.com/karmada-io/karmada/pull/1289
https://github.com/kubernetes/kubernetes/pull/104503