### PR TITLE
fix: log cluster name empty when update failure

### DIFF
--- a/pkg/synchromanager/clustersynchro_manager.go
+++ b/pkg/synchromanager/clustersynchro_manager.go
@@ -224,8 +224,8 @@ func (manager *Manager) reconcileCluster(cluster *clusterv1alpha2.PediaCluster) 
 	// ensure finalizer
 	if !controllerutil.ContainsFinalizer(cluster, ClusterSynchroControllerFinalizer) {
 		controllerutil.AddFinalizer(cluster, ClusterSynchroControllerFinalizer)
-		cluster, err = manager.clusterpediaclient.ClusterV1alpha2().PediaClusters().Update(context.TODO(), cluster, metav1.UpdateOptions{})
-		if err != nil {
+
+		if _, err = manager.clusterpediaclient.ClusterV1alpha2().PediaClusters().Update(context.TODO(), cluster, metav1.UpdateOptions{}); err != nil {
 			klog.ErrorS(err, "Failed to add finializer", "cluster", cluster.Name)
 			return err
 		}


### PR DESCRIPTION
update failure client will return a empty object
pkg/generated/clientset/versioned/typed/cluster/v1alpha2/pediacluster.go
```
// Update takes the representation of a pediaCluster and updates it. Returns the server's representation of the pediaCluster, and an error, if there is any.
func (c *pediaClusters) Update(ctx context.Context, pediaCluster *v1alpha2.PediaCluster, opts v1.UpdateOptions) (result *v1alpha2.PediaCluster, err error) {
	result = &v1alpha2.PediaCluster{}
	err = c.client.Put().
		Resource("pediaclusters").
		Name(pediaCluster.Name).
		VersionedParams(&opts, scheme.ParameterCodec).
		Body(pediaCluster).
		Do(ctx).
		Into(result)
	return
}
```
k8s.io/client-go/rest/request.go
```
// Into stores the result into obj, if possible. If obj is nil it is ignored.
// If the returned object is of type Status and has .Status != StatusSuccess, the
// additional information in Status will be used to enrich the error.
func (r Result) Into(obj runtime.Object) error {
	if r.err != nil {
		// Check whether the result has a Status object in the body and prefer that.
		return r.Error()
	}
	if r.decoder == nil {
		return fmt.Errorf("serializer for %s doesn't exist", r.contentType)
	}
	if len(r.body) == 0 {
		return fmt.Errorf("0-length response with status code: %d and content type: %s",
			r.statusCode, r.contentType)
	}

	out, _, err := r.decoder.Decode(r.body, nil, obj)
	if err != nil || out == obj {
		return err
	}
	// if a different object is returned, see if it is Status and avoid double decoding
	// the object.
	switch t := out.(type) {
	case *metav1.Status:
		// any status besides StatusSuccess is considered an error.
		if t.Status != metav1.StatusSuccess {
			return errors.FromObject(t)
		}
	}
	return nil

```