### PR TITLE
fix:cmd/clustersynchro-manager has duplicated log tags

### DIFF
--- a/cmd/clustersynchro-manager/app/synchro.go
+++ b/cmd/clustersynchro-manager/app/synchro.go
@@ -67,7 +67,7 @@ func NewClusterSynchroManagerCommand(ctx context.Context) *cobra.Command {
 
 	namedFlagSets := opts.Flags()
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
-	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name())
+	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), cmd.Name(), logs.SkipLoggingConfigurationFlags())
 	clusterpediafeature.MutableFeatureGate.AddFlag(namedFlagSets.FlagSet("mutable feature gate"))
 
 	fs := cmd.Flags()


### PR DESCRIPTION
Signed-off-by: ONE7live <wangqi_yewu@cmss.chinamobile.com> 

#238 

fix:cmd/clustersynchro-manager has duplicated log tags.