### PR TITLE
fix chart role name

### DIFF
--- a/charts/templates/clusterrole.yaml
+++ b/charts/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 rules:
   - apiGroups: ['*']

--- a/charts/templates/clusterrolebinding.yaml
+++ b/charts/templates/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}
+  name: {{ include "common.names.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "clusterpedia.apiserver.fullname" . }}


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind bug

If the chart as a sub chart, `Release.name` is very easy to conflict with parent chart. we should try not to use 'release.name' directly.