### PR TITLE
fix storage images registry

### DIFF
--- a/charts/Chart.lock
+++ b/charts/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.14.2
-digest: sha256:c8707d4c909ac38d71248b8bce3e5312495337179dde0a127ae7556138689648
-generated: "2022-06-01T17:36:16.325975954+08:00"
+digest: sha256:f703f3beccf530dbed3eeadfddd0e093e8e5328e62fd6c9efde2f5842b9c07dd
+generated: "2022-08-14T20:16:23.521861+08:00"

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -28,11 +28,11 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 11.6.0
+    version: 11.x.x
   - condition: mysql.enabled
     name: mysql
     repository: https://charts.bitnami.com/bitnami
-    version: 9.1.2
+    version: 9.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 1.14.2
+    version: 1.x.x

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -28,11 +28,11 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 11.x.x
+    version: 11.6.0
   - condition: mysql.enabled
     name: mysql
     repository: https://charts.bitnami.com/bitnami
-    version: 9.x.x
+    version: 9.1.2
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 1.x.x
+    version: 1.14.2

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -22,7 +22,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" (include "common.names.fullname" .) "controller-manager" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-
 {{/*
 Return the proper apiserver image name
 */}}
@@ -165,7 +164,7 @@ Return the proper Docker Image Registry Secret Names
      {{- if eq (include "clusterpedia.storage.type" .) "postgres" -}}
      {{- .Values.postgresql.primary.service.ports.postgresql -}}
           {{- else if eq (include "clusterpedia.storage.type" .) "mysql" -}}
-     {{- .Values.mysql.primary.service.ports.mysql -}}
+     {{- .Values.mysql.primary.service.ports -}}
      {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -279,18 +278,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the proper postgresql image name
+*/}}
 {{- define "clusterpedia.storage.postgresql.image" -}}
-{{- $registryName := .Values.postgresql.image.registry -}}
-{{- $repositoryName := .Values.postgresql.image.repository -}}
-{{- $tag := .Values.postgresql.image.tag -}}
-{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.postgresql.image "global" .Values.global) }}
 {{- end -}}
 
+{{/*
+Return the proper mysql image name
+*/}}
 {{- define "clusterpedia.storage.mysql.image" -}}
-{{- $registryName := .Values.mysql.image.registry -}}
-{{- $repositoryName := .Values.mysql.image.repository -}}
-{{- $tag := .Values.mysql.image.tag -}}
-{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.mysql.image "global" .Values.global) }}
 {{- end -}}
 
 {{- define "clusterpedia.storage.mountPath" -}}


### PR DESCRIPTION
Signed-off-by: calvin <wen.chen@daocloud.io>

/kind bug

The storage (postgresql & mysql) is out of `global.imaesRegistry` control.