### PR TITLE
retry to remove the pediacluster's finalizer

### DIFF
--- a/pkg/synchromanager/clustersynchro_manager.go
+++ b/pkg/synchromanager/clustersynchro_manager.go
@@ -246,9 +246,18 @@ func (manager *Manager) reconcileCluster(cluster *clusterv1alpha2.PediaCluster) 
 			return controller.NoRequeueResult
 		}
 
-		// remove finalizer
-		controllerutil.RemoveFinalizer(cluster, ClusterSynchroControllerFinalizer)
-		if _, err := manager.clusterpediaclient.ClusterV1alpha2().PediaClusters().Update(context.TODO(), cluster, metav1.UpdateOptions{}); err != nil {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			cluster, err := manager.clusterlister.Get(cluster.Name)
+			if err != nil {
+				return err
+			}
+			cluster = cluster.DeepCopy()
+
+			// remove finalizer
+			controllerutil.RemoveFinalizer(cluster, ClusterSynchroControllerFinalizer)
+			_, err = manager.clusterpediaclient.ClusterV1alpha2().PediaClusters().Update(context.TODO(), cluster, metav1.UpdateOptions{})
+			return err
+		}); err != nil && !apierrors.IsNotFound(err) {
 			klog.ErrorS(err, "Failed to remove finializer", "cluster", cluster.Name)
 			return controller.RequeueResult(defaultRetryNum)
 		}


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
Use `retry.RetryOnConflict` to remove the finalizer of pediacluster
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```
