### PR TITLE
Chore: bump golang to v1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - run: hack/verify-import-aliases.sh
       - run: hack/verify-vendor.sh
       - run: hack/verify-codegen.sh
@@ -47,7 +47,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Compile
         run: make all
   test:
@@ -60,7 +60,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
       - run: make test
   e2e-test:
     name: E2e test
@@ -72,6 +72,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run e2e test
         run: ./test/test.sh

--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: 1.18
           check-latest: true
       - name: Login registry
         run: |


### PR DESCRIPTION
- update golang to v1.18

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Updating golang version to v1.18

**Which issue(s) this PR fixes**:
Fixes #301 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
