### PR TITLE
Mv ioutil.ReadFile to os.ReadFile for fixing ci error

### DIFF
--- a/pkg/storage/internalstorage/config.go
+++ b/pkg/storage/internalstorage/config.go
@@ -5,8 +5,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"time"
 
@@ -310,7 +310,7 @@ func configTLS(host, sslmode, sslrootcert, sslcert, sslkey string) (*tls.Config,
 		caCertPool := x509.NewCertPool()
 
 		caPath := sslrootcert
-		caCert, err := ioutil.ReadFile(caPath)
+		caCert, err := os.ReadFile(caPath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read CA file: %w", err)
 		}


### PR DESCRIPTION
Signed-off-by: wuyingjun <wuyingjun_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
package ioutil is deprecated and this function(ioutil.ReadFile ) simply calls os.ReadFile.
**Which issue(s) this PR fixes**:
Fixes  https://github.com/clusterpedia-io/clusterpedia/issues/306

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
