### PR TITLE
Friendly printing pediaclusterlifecycle and clusterimportlifecycle 

### DIFF
--- a/charts/_crds/policy.clusterpedia.io_clusterimportpolicies.yaml
+++ b/charts/_crds/policy.clusterpedia.io_clusterimportpolicies.yaml
@@ -15,7 +15,14 @@ spec:
     singular: clusterimportpolicy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type == 'Validated')].reason
+      name: Validated
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'Reconciling')].reason
+      name: Reconciling
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/charts/_crds/policy.clusterpedia.io_pediaclusterlifecycles.yaml
+++ b/charts/_crds/policy.clusterpedia.io_pediaclusterlifecycles.yaml
@@ -15,7 +15,14 @@ spec:
     singular: pediaclusterlifecycle
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type == 'Created')].reason
+      name: Created
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'Updating')].reason
+      name: Updating
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         properties:

--- a/staging/src/github.com/clusterpedia-io/api/policy/v1alpha1/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/policy/v1alpha1/types.go
@@ -25,6 +25,8 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope="Cluster"
+// +kubebuilder:printcolumn:name="Validated",type=string,JSONPath=".status.conditions[?(@.type == 'Validated')].reason"
+// +kubebuilder:printcolumn:name="Reconciling",type=string,JSONPath=".status.conditions[?(@.type == 'Reconciling')].reason"
 type ClusterImportPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -69,6 +71,8 @@ type ClusterImportPolicyStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope="Cluster"
+// +kubebuilder:printcolumn:name="Created",type=string,JSONPath=".status.conditions[?(@.type == 'Created')].reason"
+// +kubebuilder:printcolumn:name="Updating",type=string,JSONPath=".status.conditions[?(@.type == 'Updating')].reason"
 type PediaClusterLifecycle struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Friendly kubectl get pediaclusterlifecycle and kubectl get clusterimportlifecycle printing

Signed-off-by: qiuming520 <qiuming_yewu@cmss.chinamobile.com>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Friendly kubectl get pediaclusterlifecycle and kubectl get clusterimportlifecycle printing

**Which issue(s) this PR fixes**:
Fixes #https://github.com/clusterpedia-io/clusterpedia/issues/292

before：
![图片](https://user-images.githubusercontent.com/10718885/184125659-715145e0-577a-4e4c-8d2f-cddddad265d9.png)
![图片](https://user-images.githubusercontent.com/10718885/184125778-7f02e3e9-dbac-4857-bdfa-4d2fc24bf6dc.png)

after：
![图片](https://user-images.githubusercontent.com/10718885/184125860-cfed6ced-cd01-403e-8d94-e6b99e2e580e.png)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
