### PR TITLE
add source.selectorTemplate field for ClusterImportPolicy

### DIFF
--- a/charts/clusterpedia/_crds/policy.clusterpedia.io_clusterimportpolicies.yaml
+++ b/charts/clusterpedia/_crds/policy.clusterpedia.io_clusterimportpolicies.yaml
@@ -77,6 +77,8 @@ spec:
                     type: string
                   resource:
                     type: string
+                  selectorTemplate:
+                    type: string
                   versions:
                     items:
                       type: string

--- a/examples/clusterimportpolicy.yaml
+++ b/examples/clusterimportpolicy.yaml
@@ -6,6 +6,8 @@ spec:
   source:
     group: ""
     resource: secrets
+    selectorTemplate: |
+      {{ if eq .source.metadata.namespace "default" }} true {{ end }}
   nameTemplate: 'secret-{{ .source.metadata.namespace }}-{{ .source.metadata.name }}'
   template: |
     spec:

--- a/staging/src/github.com/clusterpedia-io/api/policy/v1alpha1/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/policy/v1alpha1/types.go
@@ -270,10 +270,19 @@ type SourceType struct {
 	// +required
 	// +kubebuilder:validation:Required
 	Resource string `json:"resource"`
+
+	// +optional
+	SelectorTemplate SelectorTemplate `json:"selectorTemplate,omitempty"`
 }
 
 func (st SourceType) GroupResource() schema.GroupResource {
 	return schema.GroupResource{Group: st.Group, Resource: st.Resource}
+}
+
+type SelectorTemplate string
+
+func (t SelectorTemplate) Template() (*template.Template, error) {
+	return newTemplate("select-source", string(t))
 }
 
 type DependentResource struct {


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
Filter unwanted sources to avoid creating useless PediaClusterLifecycles

**Which issue(s) this PR fixes**:
issues: https://github.com/clusterpedia-io/clusterpedia/issues/243

**Special notes for your reviewer**:
example:
```yaml
apiVersion: policy.clusterpedia.io/v1alpha1
kind: ClusterImportPolicy
metadata:
  name: secret
spec:
  source:
    group: ""
    resource: secrets
    selectorTemplate: |
      {{ if eq .source.metadata.namespace "default" }} true {{ end }}
  nameTemplate: 'secret-{{ .source.metadata.namespace }}-{{ .source.metadata.name }}'
  template: |
    spec:
      apiserver: "https://127.0.0.1"
      syncResources:
        - group: ""
          resources:
            - "pods"
            - "configmaps"
      syncResourcesRefName: ""
  creationCondition: |
    {{ if eq .source.metadata.namespace "default" }}
      {{ if eq .source.metadata.name "my-secret" }}
        true
      {{ end }}
    {{ end }}
```

sample:
```bash
$ kubectl apply -f examples/clusterimportpolicy.yaml
$ kubectl get clusterimportpolicies
NAME     VALIDATED   RECONCILING
secret   Success     ReconcileSourceResourceAndLifecycle

$  kubectl get pediaclusterlifecycle
NAME                                                            AGE
secret-default-cloud-controller-manager                         52s
secret-default-cloud-provider-vsphere-credentials               52s
secret-default-clusterpedia-synchro-token-95kdx                 52s
secret-default-default-token-v645c                              52s
secret-default-my-secret                                        52s
secret-default-poc                                              52s
secret-default-quickstart-ingress-nginx-admission               52s
secret-default-quickstart-ingress-nginx-admission-token-lc7p8   52s
secret-default-sh.helm.release.v1.quickstart.v1                 52s
secret-default-test-controller-manager-token-rhdx7              52s

$ kubectl get pediacluster
NAME                       READY   VERSION   APISERVER
cluster-example            False   v1.22.2   https://10.6.100.10:6443
cluster-example-2          False   v1.20.7   https://10.6.182.101:6443
secret-default-my-secret   False             https://127.0.0.1
```

Filter by namespace and label：
```yaml
apiVersion: policy.clusterpedia.io/v1alpha1
kind: ClusterImportPolicy
metadata:
  name: secret
spec:
  source:
    group: ""
    resource: secrets
    selectorTemplate: |
      {{ if eq .source.metadata.namespace "default" }}
        {{ hasKey .source.metadata.labels "clusterpedia" }}
      {{ end }}
  nameTemplate: 'secret-{{ .source.metadata.namespace }}-{{ .source.metadata.name }}'
  template: |
    spec:
      apiserver: "https://127.0.0.1"
      syncResources:
        - group: ""
          resources:
            - "pods"
            - "configmaps"
      syncResourcesRefName: ""
  creationCondition: |
    {{ if eq .source.metadata.namespace "default" }}
      {{ if eq .source.metadata.name "my-secret" }}
        true
      {{ end }}
    {{ end }}
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
