### PR TITLE
add clusterimportpolicy yaml for vcluster

### DIFF
--- a/deploy/clusterimportpolicy/vcluster.yaml
+++ b/deploy/clusterimportpolicy/vcluster.yaml
@@ -1,0 +1,42 @@
+apiVersion: policy.clusterpedia.io/v1alpha1
+kind: ClusterImportPolicy
+metadata:
+  name: vcluster
+spec:
+  source:
+    group: ""
+    resource: secrets
+    selectorTemplate: |
+      {{ if hasPrefix "vc-" .source.metadata.name }}
+        {{ $ca := (get .source.data "certificate-authority") }}
+        {{ $clientca := (get .source.data "client-certificate") }}
+        {{ $clientkey := (get .source.data "client-key") }}
+
+        {{/* Use a specific data format tofilter out the vcluster's secret */}}
+        {{ if and $ca $clientca $clientkey (hasKey .source.data "config") }}
+          {{ $kubeconfig := (b64dec .source.data.config) }}
+          {{ and
+            (contains $ca $kubeconfig)
+            (contains $clientca $kubeconfig)
+            (contains $clientkey $kubeconfig)
+           }}
+        {{ end }}
+      {{ end }}
+  nameTemplate: 'vc-{{ .source.metadata.namespace }}-{{ trimPrefix "vc-" .source.metadata.name }}'
+  template: |
+    spec:
+      apiserver: 'https://{{ trimPrefix "vc-" .source.metadata.name }}.{{ .source.metadata.namespace }}.svc'
+      kubeconfig: '{{ .source.data.config }}'
+      syncResources:
+        - group: ""
+          resources:
+          - "pods"
+          - "services"
+          - "configmaps"
+          - "secrets"
+          - "namespaces"
+        - group: "apps"
+          resources:
+            - "*"
+      syncResourcesRefName: ""
+  creationCondition: "true"


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
add clusterimportpolicy yaml for vcluster, clusterpedia can automatically  import clusters created with vcluster.

get clusterimportpolicies in host cluster
```bash
$ kubectl get clusterimportpolicy
NAME          VALIDATED   RECONCILING
cluster-api   Success     ReconcileSourceResourceAndLifecycle
vcluster      Success     ReconcileSourceResourceAndLifecycle
```

list cluster that created by vcluster.
```bash
$ vcluster list

 NAME          NAMESPACE     STATUS    CONNECTED   CREATED                         AGE
 my-vcluster   my-vcluster   Running               2022-08-18 17:47:32 +0800 CST   20m2s
```

clusterpedia can automatically import clusters created with vcluster
```bash
$ kubectl get pediaclusterlifecycle
NAME                         AGE
default-capi-quickstart-2    14d
vc-my-vcluster-my-vcluster   12m

$ kubectl get pediacluster
NAME                         READY   VERSION        APISERVER
default-capi-quickstart-2    True    v1.24.2
vc-my-vcluster-my-vcluster   True    v1.23.5+k3s1   https://my-vcluster.my-vcluster.svc
```

search resources
```bash
$  kubectl --cluster clusterpedia get node
CLUSTER                      NAME                                            STATUS     ROLES           AGE   VERSION
default-capi-quickstart-2    capi-quickstart-2-ctm9k-g2m87                   NotReady   control-plane   14d   v1.24.2
default-capi-quickstart-2    capi-quickstart-2-md-0-s8hbx-7bd44554b5-kzcb6   NotReady   <none>          14d   v1.24.2
vc-my-vcluster-my-vcluster   kind-control-plane                              Ready      <none>          20m   v1.23.5+k3s1

$ kubectl --cluster clusterpedia get cm -A
NAMESPACE         CLUSTER                      NAME                                 DATA   AGE
default           vc-my-vcluster-my-vcluster   kube-root-ca.crt                     1      3h20m
default           default-capi-quickstart-2    kube-root-ca.crt                     1      14d
kube-node-lease   vc-my-vcluster-my-vcluster   kube-root-ca.crt                     1      3h20m
kube-node-lease   default-capi-quickstart-2    kube-root-ca.crt                     1      14d
kube-public       default-capi-quickstart-2    cluster-info                         1      14d
kube-public       vc-my-vcluster-my-vcluster   kube-root-ca.crt                     1      3h20m
kube-public       default-capi-quickstart-2    kube-root-ca.crt                     1      14d
kube-system       vc-my-vcluster-my-vcluster   cluster-dns                          2      3h20m
kube-system       vc-my-vcluster-my-vcluster   coredns                              2      3h20m
kube-system       default-capi-quickstart-2    coredns                              1      14d
kube-system       vc-my-vcluster-my-vcluster   extension-apiserver-authentication   6      3h20m
kube-system       default-capi-quickstart-2    extension-apiserver-authentication   6      14d
kube-system       default-capi-quickstart-2    kubeadm-config                       1      14d
kube-system       default-capi-quickstart-2    kubelet-config                       1      14d
kube-system       default-capi-quickstart-2    kube-proxy                           2      14d
kube-system       vc-my-vcluster-my-vcluster   kube-root-ca.crt                     1      3h20m
kube-system       default-capi-quickstart-2    kube-root-ca.crt                     1      14d
```

More uses sample —— https://clusterpedia.io/docs/usage/search/


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
**vcluster repo** —— https://github.com/loft-sh/vcluster
**crossplane + vcluster** —— https://github.com/salaboy/from-monolith-to-k8s/tree/main/platform

**When creating the VCluster we need to set the server in the generated kube config so that we can access it within the host cluster**, the default is 127.0.0.1.
```yaml
values.yaml
syncer:
  extraArgs:
  - --out-kube-config-server=https://<vcluster name>.<namespace>.svc
  - --tls-san=<vcluster name>.<namespace>.svc
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
