### PR TITLE
sync apiregistration resources

### DIFF
--- a/pkg/synchromanager/clustersynchro/apiservice_controller.go
+++ b/pkg/synchromanager/clustersynchro/apiservice_controller.go
@@ -145,6 +145,9 @@ func (c *APIServiceController) reconcile() {
 		}
 	}
 
+	// The kube-aggregator does not register `apiregistration.k8s.io` as an APIService resource, we need to add `apiregistration.k8s.io/v1` to the **groupVersions**
+	groupVersions[apiregistrationv1api.SchemeGroupVersion.Group] = []string{apiregistrationv1api.SchemeGroupVersion.Version}
+
 	// full update, ensuring version order
 	c.discoveryCache.SetGroupVersions(groupVersions, aggregatorGroups)
 }


### PR DESCRIPTION
**What type of PR is this?**
add apiregistration to discovery cache to support sync apiregistration resources
<!--
Add one of the following kinds:
/kind feature

-->

**What this PR does / why we need it**:
The kube-aggregator does not register `apiregistration.k8s.io` as an APIService resource, we need to add `apiregistration.k8s.io/v1` to the **groupVersions**

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
