### PR TITLE
internalstorage: update default conn pool

### DIFF
--- a/pkg/storage/internalstorage/config.go
+++ b/pkg/storage/internalstorage/config.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	defaultMaxIdleConns    = 10
-	defaultMaxOpenConns    = 100
+	defaultMaxIdleConns    = 5
+	defaultMaxOpenConns    = 40
 	defaultConnMaxLifetime = time.Hour
 )
 


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup
**What this PR does / why we need it**:
The default max_connections for mysql is 100, the MaxOpenConnections for a clusterpedia component should be less than the default max_connections,
 and clusterpedia will have two components using the database, so each component needs to be at least less than 50.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
