### PR TITLE
support order by raw sql

### DIFF
--- a/pkg/storage/internalstorage/util_test.go
+++ b/pkg/storage/internalstorage/util_test.go
@@ -374,7 +374,7 @@ func TestApplyListOptionsToQuery_OrderBy(t *testing.T) {
 		expected expected
 	}{
 		{
-			"asec",
+			"asc",
 			[]internal.OrderBy{
 				{Field: "namespace"},
 				{Field: "name"},
@@ -388,7 +388,7 @@ func TestApplyListOptionsToQuery_OrderBy(t *testing.T) {
 			},
 		},
 		{
-			"dsec",
+			"desc",
 			[]internal.OrderBy{
 				{Field: "namespace"},
 				{Field: "name", Desc: true},
@@ -402,15 +402,36 @@ func TestApplyListOptionsToQuery_OrderBy(t *testing.T) {
 			},
 		},
 		{
-			"with not support fields",
+			"order by custom fields asc",
 			[]internal.OrderBy{
-				{Field: "name"},
-				{Field: "group"},
-				{Field: "cluster"},
+				{Field: "JSON_EXTRACT(object,'$.status.podIP')"},
 			},
 			expected{
-				`SELECT * FROM "resources" ORDER BY name,cluster `,
-				"SELECT * FROM `resources` ORDER BY name,cluster ",
+				`SELECT * FROM "resources" ORDER BY JSON_EXTRACT(object,'$.status.podIP') `,
+				"SELECT * FROM `resources` ORDER BY JSON_EXTRACT(object,'$.status.podIP') ",
+				"",
+			},
+		},
+		{
+			"order by custom fields desc",
+			[]internal.OrderBy{
+				{Field: "JSON_EXTRACT(object,'$.status.podIP')", Desc: true},
+			},
+			expected{
+				`SELECT * FROM "resources" ORDER BY JSON_EXTRACT(object,'$.status.podIP') DESC `,
+				"SELECT * FROM `resources` ORDER BY JSON_EXTRACT(object,'$.status.podIP') DESC ",
+				"",
+			},
+		},
+		{
+			"order by multiple fields",
+			[]internal.OrderBy{
+				{Field: "JSON_EXTRACT(object,'$.status.podIP')", Desc: true},
+				{Field: "name"},
+			},
+			expected{
+				`SELECT * FROM "resources" ORDER BY JSON_EXTRACT(object,'$.status.podIP') DESC,name `,
+				"SELECT * FROM `resources` ORDER BY JSON_EXTRACT(object,'$.status.podIP') DESC,name ",
 				"",
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**
support order by raw sql
<!--
Add one of the following kinds:
/kind feature

-->

**What this PR does / why we need it**:
The previous sorting can only be performed according to the specified fields, which limits the actual use.Therefore, it is necessary to support user-defined fields

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
None
```
