### PR TITLE
Bump golangci lint to v1.49.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.49.0
   vertify:
     name: Vertify import alias, vendor, codegen, crds
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ clean-controller-manager-manifest:
 .PHONY: golangci-lint
 golangci-lint:
 ifeq (, $(shell which golangci-lint))
-	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 GOLANGLINT_BIN=$(shell go env GOPATH)/bin/golangci-lint
 else
 GOLANGLINT_BIN=$(shell which golangci-lint)


### PR DESCRIPTION
Signed-off-by: rongfu.leng <rongfu.leng@daocloud.io>