### PR TITLE
Support Create Database to External Storage

### DIFF
--- a/charts/clusterpedia/templates/_helpers.tpl
+++ b/charts/clusterpedia/templates/_helpers.tpl
@@ -188,7 +188,7 @@ Return the proper Docker Image Registry Secret Names
      {{- if empty .Values.externalStorage.database }}
           {{ required "Please set correct storage database!" "" }}
      {{- else -}}
-          {{- .Values.externalStorage.database | quote -}}
+          {{- .Values.externalStorage.database }}
      {{- end -}}
 {{- else -}}
      {{- "clusterpedia" -}}
@@ -304,5 +304,13 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
      {{- .Values.postgresql.primary.persistence.selector.matchLables -}}
 {{- else if eq (include "clusterpedia.storage.type" .) "mysql" -}}
      {{- .Values.mysql.primary.persistence.selector.matchLabels -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "clusterpedia.storage.password.envKey" -}}
+{{- if eq (include "clusterpedia.storage.type" .) "postgres" }}
+     {{- "PGPASSWORD" -}}
+{{- else if eq (include "clusterpedia.storage.type" .) "mysql" -}}
+     {{- "DB_PASSWORD" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/clusterpedia/templates/apiserver-deployment.yaml
+++ b/charts/clusterpedia/templates/apiserver-deployment.yaml
@@ -30,6 +30,32 @@ spec:
     spec:
       {{- include "clusterpedia.apiserver.imagePullSecrets" . | nindent 6 }}
       initContainers:
+    {{- if .Values.externalStorage.createDatabase }}
+      - name: ensure-database
+        image: {{ include "clusterpedia.storage.image" . }}
+        command:
+          - /bin/sh
+          - -ec
+          {{- if eq (include "clusterpedia.storage.type" .) "postgres" }}
+          - |
+            until psql -U {{ include "clusterpedia.storage.user" . }} -h {{ include "clusterpedia.storage.host" . }} -p {{ include "clusterpedia.storage.port" . }} postgres -c "SELECT 1 FROM pg_database WHERE datname = '{{ include "clusterpedia.storage.database" . }}'" | grep -q 1 || psql -U {{ include "clusterpedia.storage.user" . }} -h {{ include "clusterpedia.storage.host" . }} -p {{ include "clusterpedia.storage.port" . }} postgres -c "CREATE DATABASE {{ include "clusterpedia.storage.database" . }} owner {{ include "clusterpedia.storage.user" . }} " -c "GRANT ALL PRIVILEGES ON DATABASE {{ include "clusterpedia.storage.database" . }} to {{ include "clusterpedia.storage.user" . }}"; do 
+            echo waiting for database check && sleep 1;
+            done;
+            echo 'DataBase OK ✓'
+          {{- else if eq (include "clusterpedia.storage.type" .) "mysql" }}
+          - |
+            until mysql -u{{ include "clusterpedia.storage.user" . }} -p"${DB_PASSWORD}" --host={{ include "clusterpedia.storage.host" . }} --port={{ include "clusterpedia.storage.port" . }} -e 'CREATE DATABASE IF NOT EXISTS {{ include "clusterpedia.storage.database" . }}'; do
+            echo waiting for database check && sleep 1; 
+            done;
+            echo 'DataBase OK ✓'
+          {{- end }}
+        env:
+          - name: {{ include "clusterpedia.storage.password.envKey" . }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "clusterpedia.internalstorage.fullname" . }}
+                key: password
+    {{- else }}
       - name: check-storage
         image: {{ include "clusterpedia.storage.image" . }}
         command: 
@@ -48,6 +74,7 @@ spec:
                 name: {{ include "clusterpedia.internalstorage.fullname" . }}
                 key: password
       {{- end }}
+    {{- end }}
       containers:
       - name: {{ include "clusterpedia.apiserver.fullname" . }}
         image: {{ template "clusterpedia.apiserver.image" . }}

--- a/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
+++ b/charts/clusterpedia/templates/clustersynchro-manager-deployment.yaml
@@ -30,6 +30,32 @@ spec:
     spec:
       {{- include "clusterpedia.clustersynchroManager.imagePullSecrets" . | nindent 6 }}
       initContainers:
+    {{- if .Values.externalStorage.createDatabase }}
+      - name: ensure-database
+        image: {{ include "clusterpedia.storage.image" . }}
+        command:
+          - /bin/sh
+          - -ec
+          {{- if eq (include "clusterpedia.storage.type" .) "postgres" }}
+          - |
+            until psql -U {{ include "clusterpedia.storage.user" . }} -h {{ include "clusterpedia.storage.host" . }} -p {{ include "clusterpedia.storage.port" . }} postgres -c "SELECT 1 FROM pg_database WHERE datname = '{{ include "clusterpedia.storage.database" . }}'" | grep -q 1 || psql -U {{ include "clusterpedia.storage.user" . }} -h {{ include "clusterpedia.storage.host" . }} -p {{ include "clusterpedia.storage.port" . }} postgres -c "CREATE DATABASE {{ include "clusterpedia.storage.database" . }} owner {{ include "clusterpedia.storage.user" . }} " -c "GRANT ALL PRIVILEGES ON DATABASE {{ include "clusterpedia.storage.database" . }} to {{ include "clusterpedia.storage.user" . }}"; do 
+            echo waiting for database check && sleep 1;
+            done;
+            echo 'DataBase OK ✓'
+          {{- else if eq (include "clusterpedia.storage.type" .) "mysql" }}
+          - |
+            until mysql -u{{ include "clusterpedia.storage.user" . }} -p"${DB_PASSWORD}" --host={{ include "clusterpedia.storage.host" . }} --port={{ include "clusterpedia.storage.port" . }} -e 'CREATE DATABASE IF NOT EXISTS {{ include "clusterpedia.storage.database" . }}'; do
+            echo waiting for database check && sleep 1; 
+            done;
+            echo 'DataBase OK ✓'
+          {{- end }}
+        env:
+          - name: {{ include "clusterpedia.storage.password.envKey" . }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "clusterpedia.internalstorage.fullname" . }}
+                key: password
+    {{- else }}
       - name: check-storage
         image: {{ include "clusterpedia.storage.image" . }}
         command: 
@@ -48,6 +74,7 @@ spec:
                 name: {{ include "clusterpedia.internalstorage.fullname" . }}
                 key: password
       {{- end }}
+    {{- end }}
       containers:
       - name: {{ include "clusterpedia.clustersynchroManager.fullname" . }}
         image: {{ template "clusterpedia.clustersynchroManager.image" . }}

--- a/charts/clusterpedia/values.yaml
+++ b/charts/clusterpedia/values.yaml
@@ -71,24 +71,27 @@ storageConfig:
 ## @param external define the auth param of external database
 ## if set the storageInstallMode to "external", the param must be set.
 externalStorage:
-  ## @param database Select which database backend Clusterpedia will use. Can be 'postgres' or 'mysql'
+  ## @param externalStorage.type Select which database backend Clusterpedia will use. Can be 'postgres' or 'mysql'
   ##
   type: ""
-  ## @param auth.host for a custom host
+  ## @param externalStorage.host for a custom host
   ##
   host: ""
-  ## @param auth.port for a custom port
+  ## @param externalStorage.port for a custom port
   ##
   port:
-  ## @param auth.user Name for a custom user
+  ## @param externalStorage.user Name for a custom user
   ##
   user: ""
-  ## @param auth.password Password for a custom password
+  ## @param externalStorage.password Password for a custom password
   ##
   password: ""
-  ## @param auth.database Name for a custom database
+  ## @param externalStorage.database Name for a custom database
   ##
   database: ""
+  ## @param externalStorage.createDatabase whether to create the .Values.externalStorage.database or not
+  ##
+  createDatabase: false
 
 ## clusterpedia apiserver config
 apiserver:


### PR DESCRIPTION
Signed-off-by: RuliXu <lily.xu@daocloud.io>

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Clusterpedia may work together with other system which already has a storage component, to better share this component, clusterpedia should support to create database with the permission of the user.

This PR adds a flag `createDatabase` to values, which defaults to be false and needs to be actively set to true by the user to create the database, to ensure that the user is explicitly aware that a high privilege operation is being performed.

`--set externalStorage.createDatabase=true` will render an init container for creating the database into the core component deployments.

**Which issue(s) this PR fixes**:
https://github.com/clusterpedia-io/clusterpedia/issues/326

**Special notes for your reviewer**:

## 1. External Storage Create Database
### Mysql
![image](https://user-images.githubusercontent.com/56576505/190579070-4b776984-0646-4017-b534-c4cfe3258ff3.png)

### Postgresql
![image](https://user-images.githubusercontent.com/56576505/190580181-f0c4e7a4-5ab4-407f-b3cc-de9c8a1cffb9.png)

## 2. External Storage Not Create Database
### Mysql
![image](https://user-images.githubusercontent.com/56576505/190579438-2ca5c34b-3759-437c-8af5-d2eb4f69086a.png)

### Postgresql
![image](https://user-images.githubusercontent.com/56576505/190580472-a698abdd-bb9f-4b65-9bc2-15a50a78e00a.png)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
