### PR TITLE
optimize cluster monitor logic

### DIFF
--- a/pkg/synchromanager/clustersynchro/cluster_monitor.go
+++ b/pkg/synchromanager/clustersynchro/cluster_monitor.go
@@ -17,7 +17,7 @@ import (
 func (synchro *ClusterSynchro) monitor() {
 	klog.V(2).InfoS("Cluster Synchro Monitor Running...", "cluster", synchro.name)
 
-	wait.JitterUntil(synchro.checkClusterHealthy, 5*time.Second, 0.5, false, synchro.closer)
+	wait.JitterUntil(synchro.checkClusterHealthy, 5*time.Second, 0.5, true, synchro.closer)
 
 	healthyCondition := metav1.Condition{
 		Type:               clusterv1alpha2.ClusterHealthyCondition,


### PR DESCRIPTION
Signed-off-by: cleverhu <shouping.hu@daocloud.io>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:
Monitor the cluster status after waiting for five seconds each time.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
