### PR TITLE
use standalone tcp for health checker

### DIFF
--- a/pkg/synchromanager/clustersynchro/cluster_monitor.go
+++ b/pkg/synchromanager/clustersynchro/cluster_monitor.go
@@ -8,7 +8,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	clusterv1alpha2 "github.com/clusterpedia-io/api/cluster/v1alpha2"
@@ -36,7 +37,9 @@ func (synchro *ClusterSynchro) checkClusterHealthy() {
 	defer synchro.updateStatus()
 	lastReadyCondition := synchro.healthyCondition.Load().(metav1.Condition)
 
-	if ready, err := checkKubeHealthy(synchro.clusterclient); !ready {
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+	if ready, err := synchro.healthChecker.Ready(ctx); !ready {
 		// if the last status was not ConditionTrue, stop resource synchros
 		if lastReadyCondition.Status != metav1.ConditionTrue {
 			synchro.stopRunner()
@@ -86,17 +89,25 @@ func (synchro *ClusterSynchro) checkClusterHealthy() {
 	synchro.healthyCondition.Store(condition)
 }
 
-// TODO(iceber): resolve for more detailed error
-func checkKubeHealthy(client kubernetes.Interface) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
-	defer cancel()
+type healthChecker struct {
+	client rest.Interface
+}
 
-	_, err := client.Discovery().RESTClient().Get().AbsPath("/readyz").DoRaw(ctx)
-	if apierrors.IsNotFound(err) {
-		_, err = client.Discovery().RESTClient().Get().AbsPath("/healthz").DoRaw(ctx)
-	}
+func newHealthChecker(config *rest.Config) (*healthChecker, error) {
+	client, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return true, nil
+	return &healthChecker{
+		client: client.RESTClient(),
+	}, nil
+}
+
+// TODO(iceber): resolve for more detailed error
+func (checker *healthChecker) Ready(ctx context.Context) (bool, error) {
+	_, err := checker.client.Get().AbsPath("/readyz").DoRaw(ctx)
+	if apierrors.IsNotFound(err) {
+		_, err = checker.client.Get().AbsPath("/healthz").DoRaw(ctx)
+	}
+	return err == nil, err
 }

--- a/pkg/synchromanager/features/features.go
+++ b/pkg/synchromanager/features/features.go
@@ -40,6 +40,11 @@ const (
 	// owner: @iceber
 	// alpha: v0.3.0
 	AllowSyncAllResources featuregate.Feature = "AllowSyncAllResources"
+
+	// HealthCheckerWithStandaloneTCP is a feature gate for the cluster health checker to use standalone tcp
+	// owner: @iceber
+	// alpha: v0.6.0
+	HealthCheckerWithStandaloneTCP featuregate.Feature = "HealthCheckerWithStandaloneTCP"
 )
 
 func init() {
@@ -49,8 +54,9 @@ func init() {
 // defaultClusterSynchroManagerFeatureGates consists of all known clustersynchro-manager-specific feature keys.
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterSynchroManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PruneManagedFields:            {Default: true, PreRelease: featuregate.Beta},
-	PruneLastAppliedConfiguration: {Default: true, PreRelease: featuregate.Beta},
-	AllowSyncAllCustomResources:   {Default: false, PreRelease: featuregate.Alpha},
-	AllowSyncAllResources:         {Default: false, PreRelease: featuregate.Alpha},
+	PruneManagedFields:             {Default: true, PreRelease: featuregate.Beta},
+	PruneLastAppliedConfiguration:  {Default: true, PreRelease: featuregate.Beta},
+	AllowSyncAllCustomResources:    {Default: false, PreRelease: featuregate.Alpha},
+	AllowSyncAllResources:          {Default: false, PreRelease: featuregate.Alpha},
+	HealthCheckerWithStandaloneTCP: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
When client-go creates any number of Clients with the same configuration, such as certificates, it reuses the same TCP connection.
https://github.com/kubernetes/kubernetes/blob/3f823c0daa002158b12bfb2d53bcfe433516659d/staging/src/k8s.io/client-go/transport/transport.go#L54

This results in the cluster health check interface using the same TCP connection as the resource synchronized informer, which may cause TCP blocking and increased health check latency if a large number of informers are started for the first time.
We add a feature gate - `HealthCheckerWithStandaloneTCP` to allow users to use a standalone tcp for health checks

```bash
./clustersynchro-manager --feature-gates=HealthCheckerWithStandaloneTCP=true
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
