### PR TITLE
Readiness probe with standalone tcp

### DIFF
--- a/pkg/synchromanager/clustersynchro/cluster_synchro.go
+++ b/pkg/synchromanager/clustersynchro/cluster_synchro.go
@@ -3,13 +3,14 @@ package clustersynchro
 import (
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
@@ -18,6 +19,8 @@ import (
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
 	"github.com/clusterpedia-io/clusterpedia/pkg/storageconfig"
 	"github.com/clusterpedia-io/clusterpedia/pkg/synchromanager/clustersynchro/informer"
+	"github.com/clusterpedia-io/clusterpedia/pkg/synchromanager/features"
+	clusterpediafeature "github.com/clusterpedia-io/clusterpedia/pkg/utils/feature"
 )
 
 type ClusterSynchro struct {
@@ -27,7 +30,7 @@ type ClusterSynchro struct {
 	ClusterStatusUpdater ClusterStatusUpdater
 
 	storage              storage.StorageFactory
-	clusterclient        kubernetes.Interface
+	readinessProbe       *readinessProbe
 	dynamicDiscovery     discovery.DynamicDiscoveryInterface
 	listerWatcherFactory informer.DynamicListerWatcherFactory
 
@@ -64,11 +67,6 @@ type ClusterStatusUpdater interface {
 type RetryableError error
 
 func New(name string, config *rest.Config, storage storage.StorageFactory, updater ClusterStatusUpdater) (*ClusterSynchro, error) {
-	clusterclient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create a cluster client: %w", err)
-	}
-
 	dynamicDiscovery, err := discovery.NewDynamicDiscoveryManager(name, config)
 	if err != nil {
 		return nil, RetryableError(fmt.Errorf("failed to create dynamic discovery manager: %w", err))
@@ -84,13 +82,25 @@ func New(name string, config *rest.Config, storage storage.StorageFactory, updat
 		return nil, fmt.Errorf("failed to create lister watcher factory: %w", err)
 	}
 
+	probeConfig := *config
+	if clusterpediafeature.FeatureGate.Enabled(features.ClusterReadinessProbeWithStandaloneTCP) {
+		probeConfig.Dial = (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext
+	}
+	readinessProbe, err := newReadinessProbe(&probeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a cluster health checker: %w", err)
+	}
+
 	synchro := &ClusterSynchro{
 		name:                 name,
 		RESTConfig:           config,
 		ClusterStatusUpdater: updater,
 		storage:              storage,
 
-		clusterclient:        clusterclient,
+		readinessProbe:       readinessProbe,
 		dynamicDiscovery:     dynamicDiscovery,
 		listerWatcherFactory: listWatchFactory,
 

--- a/pkg/synchromanager/features/features.go
+++ b/pkg/synchromanager/features/features.go
@@ -40,6 +40,11 @@ const (
 	// owner: @iceber
 	// alpha: v0.3.0
 	AllowSyncAllResources featuregate.Feature = "AllowSyncAllResources"
+
+	// ClusterReadinessProbeWithStandaloneTCP is a feature gate for the cluster readiness probe to use standalone tcp
+	// owner: @iceber
+	// alpha: v0.6.0
+	ClusterReadinessProbeWithStandaloneTCP featuregate.Feature = "ClusterReadinessProbeWithStandaloneTCP"
 )
 
 func init() {
@@ -49,8 +54,9 @@ func init() {
 // defaultClusterSynchroManagerFeatureGates consists of all known clustersynchro-manager-specific feature keys.
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterSynchroManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PruneManagedFields:            {Default: true, PreRelease: featuregate.Beta},
-	PruneLastAppliedConfiguration: {Default: true, PreRelease: featuregate.Beta},
-	AllowSyncAllCustomResources:   {Default: false, PreRelease: featuregate.Alpha},
-	AllowSyncAllResources:         {Default: false, PreRelease: featuregate.Alpha},
+	PruneManagedFields:                     {Default: true, PreRelease: featuregate.Beta},
+	PruneLastAppliedConfiguration:          {Default: true, PreRelease: featuregate.Beta},
+	AllowSyncAllCustomResources:            {Default: false, PreRelease: featuregate.Alpha},
+	AllowSyncAllResources:                  {Default: false, PreRelease: featuregate.Alpha},
+	ClusterReadinessProbeWithStandaloneTCP: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
When client-go creates any number of Clients with the same configuration, such as certificates, it reuses the same TCP connection.
https://github.com/kubernetes/kubernetes/blob/3f823c0daa002158b12bfb2d53bcfe433516659d/staging/src/k8s.io/client-go/transport/transport.go#L54

This results in the cluster health check interface using the same TCP connection as the resource synchronized informer, which may cause TCP blocking and increased health check latency if a large number of informers are started for the first time.
We add a feature gate - `ClusterReadinessProbeWithStandaloneTCP` to allow users to use a standalone tcp for health checks

```bash
./clustersynchro-manager --feature-gates=ClusterReadinessProbeWithStandaloneTCP=true
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
