### PR TITLE
add global cluster readiness

### DIFF
--- a/cmd/binding-apiserver/app/binding_apiserver.go
+++ b/cmd/binding-apiserver/app/binding_apiserver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/clusterpedia-io/clusterpedia/pkg/generated/clientset/versioned"
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
 	"github.com/clusterpedia-io/clusterpedia/pkg/synchromanager"
+	synchromanageroptions "github.com/clusterpedia-io/clusterpedia/pkg/synchromanager/clustersynchro/options"
 	clusterpediafeature "github.com/clusterpedia-io/clusterpedia/pkg/utils/feature"
 	"github.com/clusterpedia-io/clusterpedia/pkg/version/verflag"
 )
@@ -56,7 +57,7 @@ func NewClusterPediaServerCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			synchromanager := synchromanager.NewManager(crdclient, config.StorageFactory)
+			synchromanager := synchromanager.NewManager(crdclient, config.StorageFactory, synchromanageroptions.NewReadinessProbeOption())
 			go synchromanager.Run(1, ctx.Done())
 
 			server, err := completedConfig.New()

--- a/cmd/clustersynchro-manager/app/config/config.go
+++ b/cmd/clustersynchro-manager/app/config/config.go
@@ -7,6 +7,7 @@ import (
 
 	crdclientset "github.com/clusterpedia-io/clusterpedia/pkg/generated/clientset/versioned"
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
+	synchromanageroptions "github.com/clusterpedia-io/clusterpedia/pkg/synchromanager/clustersynchro/options"
 )
 
 type Config struct {
@@ -19,4 +20,6 @@ type Config struct {
 
 	LeaderElection   componentbaseconfig.LeaderElectionConfiguration
 	ClientConnection componentbaseconfig.ClientConnectionConfiguration
+
+	ClusterReadiness *synchromanageroptions.ReadinessProbeOption
 }

--- a/cmd/clustersynchro-manager/app/synchro.go
+++ b/cmd/clustersynchro-manager/app/synchro.go
@@ -83,7 +83,7 @@ func NewClusterSynchroManagerCommand(ctx context.Context) *cobra.Command {
 }
 
 func Run(ctx context.Context, c *config.Config) error {
-	synchromanager := synchromanager.NewManager(c.CRDClient, c.StorageFactory)
+	synchromanager := synchromanager.NewManager(c.CRDClient, c.StorageFactory, c.ClusterReadiness)
 	if !c.LeaderElection.LeaderElect {
 		synchromanager.Run(c.WorkerNumber, ctx.Done())
 		return nil

--- a/pkg/synchromanager/clustersynchro/options/options.go
+++ b/pkg/synchromanager/clustersynchro/options/options.go
@@ -1,0 +1,59 @@
+package options
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type ReadinessProbeOption struct {
+	// Number of seconds after which the probe times out.
+	// Defaults to 5 second. Minimum value is 1.
+	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+	// +optional
+	TimeoutSeconds int32 `json:"timeoutSeconds,omitempty" protobuf:"varint,3,opt,name=timeoutSeconds"`
+	// How often (in seconds) to perform the probe.
+	// Default to 5 seconds. Minimum value is 5.
+	// +optional
+	PeriodSeconds int32 `json:"periodSeconds,omitempty" protobuf:"varint,4,opt,name=periodSeconds"`
+	// Minimum consecutive failures for the probe to be considered failed after having succeeded.
+	// Defaults to 3. Minimum value is 1.
+	// +optional
+	FailureThreshold int32 `json:"failureThreshold,omitempty" protobuf:"varint,6,opt,name=failureThreshold"`
+}
+
+func NewReadinessProbeOption() *ReadinessProbeOption {
+	return &ReadinessProbeOption{
+		TimeoutSeconds:   5,
+		PeriodSeconds:    5,
+		FailureThreshold: 3,
+	}
+}
+
+func (o *ReadinessProbeOption) Validate() []error {
+	if o == nil {
+		return nil
+	}
+
+	var errs []error
+
+	if o.TimeoutSeconds <= 0 {
+		errs = append(errs, fmt.Errorf("readiness-timeout-seconds must be greater than 0"))
+	}
+
+	if o.PeriodSeconds < 3 {
+		errs = append(errs, fmt.Errorf("readiness-period-seconds must be greater than or equal to 3"))
+	}
+
+	if o.FailureThreshold <= 0 {
+		errs = append(errs, fmt.Errorf("readiness-failure-threshold must be greater than 0"))
+	}
+
+	return errs
+}
+
+func (o *ReadinessProbeOption) AddFlags(fs *pflag.FlagSet) {
+	fs.Int32Var(&o.TimeoutSeconds, "readiness-timeout-seconds", o.TimeoutSeconds, "Number of seconds after which the probe times out for cluster health monitoring.")
+	fs.Int32Var(&o.PeriodSeconds, "readiness-period-seconds", o.PeriodSeconds, "How often (in seconds) to perform the probe for cluster health monitoring.")
+	fs.Int32Var(&o.FailureThreshold, "readiness-failure-threshold", o.FailureThreshold, "Minimum consecutive failures for the probe to be considered failed after having succeeded.")
+}


### PR DESCRIPTION
**What type of PR is this?**
add global cluster health check readiness config.
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
