### PR TITLE
add retry for mysql read-only error

### DIFF
--- a/pkg/storage/internalstorage/register.go
+++ b/pkg/storage/internalstorage/register.go
@@ -51,6 +51,7 @@ func NewStorageFactory(configPath string) (storage.StorageFactory, error) {
 			return nil, err
 		}
 
+		cfg.addMysqlErrorNumbers()
 		dialector = gmysql.New(gmysql.Config{Conn: sql.OpenDB(connector)})
 	case "postgres":
 		pgconfig, err := cfg.genPostgresConfig()
@@ -58,6 +59,7 @@ func NewStorageFactory(configPath string) (storage.StorageFactory, error) {
 			return nil, err
 		}
 
+		cfg.addPostgresErrorCodes()
 		dialector = gpostgres.New(gpostgres.Config{Conn: stdlib.OpenDB(*pgconfig)})
 	default:
 		return nil, fmt.Errorf("not support storage type: %s", cfg.Type)


### PR DESCRIPTION

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug

**What this PR does / why we need it**:
Add retry for mysql read-only error. Therefore, if the database is read-only for some reason, it will attempt to recover for a while.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
