### PR TITLE
[release/0.6] fix: Wrong timeout configuration value

### DIFF
--- a/pkg/kubeapiserver/apiserver.go
+++ b/pkg/kubeapiserver/apiserver.go
@@ -3,6 +3,7 @@ package kubeapiserver
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -123,7 +124,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	genericserver.Handler.NonGoRestfulMux.Handle("/apis", discoveryManager)
 
 	resourceHandler := &ResourceHandler{
-		minRequestTimeout: c.GenericConfig.RequestTimeout,
+		minRequestTimeout: time.Duration(c.GenericConfig.MinRequestTimeout) * time.Second,
 
 		delegate:      delegate,
 		rest:          restManager,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

When I watch clueterpeida, the connection is always disconnected around 1 minute. When I watch the api-server of k8s, it will not.

"c.GenericConfig.MinRequestTimeout" should be used instead of "c.GenericConfig.RequestTimeout,"

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
