### PR TITLE
kubeapiserver: fix the table convertor of crd

### DIFF
--- a/pkg/kubeapiserver/restmanager.go
+++ b/pkg/kubeapiserver/restmanager.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -463,10 +464,11 @@ func (info RESTResourceInfo) Empty() bool {
 }
 
 var legacyResourcesWithDefaultTableConvertor = map[schema.GroupResource]struct{}{
-	apicore.Resource("limitranges"):              {},
-	rbac.Resource("roles"):                       {},
-	rbac.Resource("clusterroles"):                {},
-	apisstorage.Resource("csistoragecapacities"): {},
+	apicore.Resource("limitranges"):                     {},
+	rbac.Resource("roles"):                              {},
+	rbac.Resource("clusterroles"):                       {},
+	apisstorage.Resource("csistoragecapacities"):        {},
+	apiextensions.Resource("customresourcedefinitions"): {},
 }
 
 func GetTableConvertor(gr schema.GroupResource) rest.TableConvertor {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug
**What this PR does / why we need it**:
```bash
 kubectl --cluster global get crd

Error from server: no table handler registered for this type *apiextensions.CustomResourceDefinitionList
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
