### PR TITLE
kubeapiserver: add the table convertor for apiservices

### DIFF
--- a/pkg/kubeapiserver/printers/apiservice_handler.go
+++ b/pkg/kubeapiserver/printers/apiservice_handler.go
@@ -1,0 +1,57 @@
+package printers
+
+import (
+	"fmt"
+
+	metatable "k8s.io/apimachinery/pkg/api/meta/table"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
+	"k8s.io/kubernetes/pkg/printers"
+)
+
+func AddAPIServiceHandler(h printers.PrintHandler) {
+	columnDefinitions := []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
+		{Name: "Service", Type: "string", Description: "The reference to the service that hosts this API endpoint."},
+		{Name: "Available", Type: "string", Description: "Whether this service is available."},
+		{Name: "Age", Type: "string", Description: swaggerMetadataDescriptions["creationTimestamp"]},
+	}
+
+	_ = h.TableHandler(columnDefinitions, func(list *apiregistration.APIServiceList, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+		return metatable.MetaToTableRow(list, apiServiceHandler)
+	})
+	_ = h.TableHandler(columnDefinitions, func(apiservice *apiregistration.APIService, options printers.GenerateOptions) ([]metav1.TableRow, error) {
+		return metatable.MetaToTableRow(apiservice, apiServiceHandler)
+	})
+}
+
+// k8s.io/kube-aggregator/pkg/registry/apiservice/etcd.(*REST).ConvertToTable
+func apiServiceHandler(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+	svc := obj.(*apiregistration.APIService)
+	service := "Local"
+	if svc.Spec.Service != nil {
+		service = fmt.Sprintf("%s/%s", svc.Spec.Service.Namespace, svc.Spec.Service.Name)
+	}
+	status := string(apiregistration.ConditionUnknown)
+	if condition := getCondition(svc.Status.Conditions, "Available"); condition != nil {
+		switch {
+		case condition.Status == apiregistration.ConditionTrue:
+			status = string(condition.Status)
+		case len(condition.Reason) > 0:
+			status = fmt.Sprintf("%s (%s)", condition.Status, condition.Reason)
+		default:
+			status = string(condition.Status)
+		}
+	}
+	return []interface{}{name, service, status, age}, nil
+}
+
+func getCondition(conditions []apiregistration.APIServiceCondition, conditionType apiregistration.APIServiceConditionType) *apiregistration.APIServiceCondition {
+	for i, condition := range conditions {
+		if condition.Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/kubeapiserver/restmanager.go
+++ b/pkg/kubeapiserver/restmanager.go
@@ -478,5 +478,5 @@ func GetTableConvertor(gr schema.GroupResource) rest.TableConvertor {
 		return printers.NewDefaultTableConvertor(gr)
 	}
 
-	return printerstorage.TableConvertor{TableGenerator: printers.NewClusterTableGenerator().With(printersinternal.AddHandlers)}
+	return printerstorage.TableConvertor{TableGenerator: printers.NewClusterTableGenerator().With(printersinternal.AddHandlers, printers.AddAPIServiceHandler)}
 }

--- a/pkg/scheme/import_known_versions.go
+++ b/pkg/scheme/import_known_versions.go
@@ -3,6 +3,7 @@ package scheme
 import (
 	// These imports are the API groups the API server will support.
 	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
+	apiregistrationinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 	_ "k8s.io/kubernetes/pkg/apis/admission/install"
 	_ "k8s.io/kubernetes/pkg/apis/admissionregistration/install"
 	_ "k8s.io/kubernetes/pkg/apis/apiserverinternal/install"
@@ -29,4 +30,5 @@ import (
 
 func init() {
 	apiextensionsinstall.Install(LegacyResourceScheme)
+	apiregistrationinstall.Install(LegacyResourceScheme)
 }

--- a/vendor/k8s.io/apimachinery/pkg/api/meta/table/table.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/meta/table/table.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package table
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/duration"
+)
+
+// MetaToTableRow converts a list or object into one or more table rows. The provided rowFn is invoked for
+// each accessed item, with name and age being passed to each.
+func MetaToTableRow(obj runtime.Object, rowFn func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error)) ([]metav1.TableRow, error) {
+	if meta.IsListType(obj) {
+		rows := make([]metav1.TableRow, 0, 16)
+		err := meta.EachListItem(obj, func(obj runtime.Object) error {
+			nestedRows, err := MetaToTableRow(obj, rowFn)
+			if err != nil {
+				return err
+			}
+			rows = append(rows, nestedRows...)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		return rows, nil
+	}
+
+	rows := make([]metav1.TableRow, 0, 1)
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	row := metav1.TableRow{
+		Object: runtime.RawExtension{Object: obj},
+	}
+	row.Cells, err = rowFn(obj, m, m.GetName(), ConvertToHumanReadableDateType(m.GetCreationTimestamp()))
+	if err != nil {
+		return nil, err
+	}
+	rows = append(rows, row)
+	return rows, nil
+}
+
+// ConvertToHumanReadableDateType returns the elapsed time since timestamp in
+// human-readable approximation.
+func ConvertToHumanReadableDateType(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+	return duration.HumanDuration(time.Since(timestamp.Time))
+}

--- a/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/install/install.go
+++ b/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/install/install.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+)
+
+// Install registers the API group and adds types to a scheme
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(apiregistration.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(v1.SchemeGroupVersion, v1beta1.SchemeGroupVersion))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -679,6 +679,7 @@ k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
+k8s.io/apimachinery/pkg/api/meta/table
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/api/validation
 k8s.io/apimachinery/pkg/api/validation/path
@@ -1179,6 +1180,7 @@ k8s.io/klog/v2/internal/severity
 # k8s.io/kube-aggregator v0.0.0 => k8s.io/kube-aggregator v0.25.2
 ## explicit; go 1.19
 k8s.io/kube-aggregator/pkg/apis/apiregistration
+k8s.io/kube-aggregator/pkg/apis/apiregistration/install
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
```bash
 kubectl --cluster local get apiservices                                                                                                                     1 ↵
CLUSTER   NAME                                      SERVICE                                       AVAILABLE   AGE
global    v1.                                       Local                                         True        196d
global    v1.acid.zalan.do                          Local                                         True        5h5m
global    v1.admissionregistration.k8s.io           Local                                         True        196d
global    v1.apiextensions.k8s.io                   Local                                         True        196d
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
