### PR TITLE
fix resolve .local service domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,8 @@ RUN GOARCH=${TARGETARCH} /builder.sh ${BIN_NAME}
 FROM alpine:3.17.3
 RUN apk add --no-cache gcompat
 
+# https://pkg.go.dev/net#hdr-Name_Resolution
+ENV GODEBUG=netdns=go
+
 ARG BIN_NAME
 COPY --from=builder /clusterpedia/bin/${BIN_NAME} /usr/local/bin/${BIN_NAME}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug
**What this PR does / why we need it**:
https://pkg.go.dev/net#hdr-Name_Resolution

When cgo is enabled, if the domain name is `.local`, cgo will be called to resolve it, and then it will failed with `Failed to init storage: dial tcp: lookup clusterpedia-mysql.clusterpedia-system.svc.cluster.local: device or resource busy`

Now force `go resolver` to resolve the domain name, and in the future we can set this environment variable inside the program

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
