### PR TITLE
#546 add kube state metrics namespace command

### DIFF
--- a/pkg/kube_state_metrics/options.go
+++ b/pkg/kube_state_metrics/options.go
@@ -45,8 +45,7 @@ func NewOptions() *Options {
 		MetricDenylist:  options.MetricSet{},
 		MetricOptInList: options.MetricSet{},
 
-		Resources:  defaultResources,
-		Namespaces: options.DefaultNamespaces,
+		Resources: defaultResources,
 	}
 }
 
@@ -79,11 +78,12 @@ func (o *Options) MetricsStoreBuilderConfig() *MetricsStoreBuilderConfig {
 		return nil
 	}
 	return &MetricsStoreBuilderConfig{
-		MetricAllowlist: o.MetricAllowlist,
-		MetricDenylist:  o.MetricDenylist,
-		MetricOptInList: o.MetricOptInList,
-		Resources:       o.Resources,
-		Namespaces:      o.Namespaces,
+		MetricAllowlist:    o.MetricAllowlist,
+		MetricDenylist:     o.MetricDenylist,
+		MetricOptInList:    o.MetricOptInList,
+		Resources:          o.Resources,
+		Namespaces:         o.Namespaces,
+		NamespacesDenylist: o.NamespacesDenylist,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: scydas <scyda@outlook.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #546 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
release-note
kube-state-metrics-namespaces: Comma-separated list of namespaces to be enabled
kube-state-metrics-namespaces-denylist Comma-separated list of namespaces not to be enabled. If namespaces and namespaces-denylist are both set, only namespaces that are excluded in namespaces-denylist will be used