### PR TITLE
:seedling: migrate golang from 1.20 to 1.21.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53.3
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - run: hack/verify-import-aliases.sh
       - run: hack/verify-vendor.sh
       - run: hack/verify-codegen.sh
@@ -51,7 +51,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Compile
         run: make all
   test:
@@ -64,7 +64,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - run: make test
   e2e-test:
     name: E2e test

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7
+FROM golang:1.21.3
 
 # FROM golang:1.19.2-alpine
 # RUN apk add --no-cache build-base git bash


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
Bump Golang from 1.19 to 1.21 as 1.19 has reached end of life 
**Which issue(s) this PR fixes**:
Fixes #NA

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
