### PR TITLE
kubeapiserver/discovery: use sets.Set[T] instead of `map[T]struct{}` and optimze other code

### DIFF
--- a/pkg/kubeapiserver/discovery/discovery.go
+++ b/pkg/kubeapiserver/discovery/discovery.go
@@ -9,7 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 
@@ -164,10 +163,8 @@ func (m *DiscoveryManager) handleLegacyAPI(pathParts []string, w http.ResponseWr
 }
 
 func (m *DiscoveryManager) SetClusterGroupResource(cluster string, apis map[schema.GroupResource]ResourceDiscoveryAPI) {
-	groups := sets.Set[string]{}
 	apiversions := make(map[schema.GroupVersion][]metav1.APIResource)
-	for gr, api := range apis {
-		groups.Insert(gr.Group)
+	for _, api := range apis {
 		for version := range api.Versions {
 			apiversions[version] = append(apiversions[version], api.Resource)
 		}
@@ -191,7 +188,7 @@ func (m *DiscoveryManager) SetClusterGroupResource(cluster string, apis map[sche
 	}
 
 	allgroups := m.groupSource.GetAPIGroups()
-	apigroups := buildAPIGroups(groups, groupversions, allgroups)
+	apigroups := buildAPIGroups(groupversions, allgroups)
 
 	currentgroups := m.groupHandler.getClusterDiscoveryAPI(cluster)
 	if reflect.DeepEqual(apigroups, currentgroups) {

--- a/pkg/kubeapiserver/discovery/discovery.go
+++ b/pkg/kubeapiserver/discovery/discovery.go
@@ -91,11 +91,7 @@ func (m *DiscoveryManager) ResourceEnabled(cluster string, gvr schema.GroupVersi
 		handlers := m.versionHandler.handlers.Load().(map[string]*versionDiscoveryHandler)
 		handler = handlers[cluster]
 	}
-
-	if handler == nil {
-		return false
-	}
-	return handler.gvrs.Has(gvr.String())
+	return handler != nil && handler.gvrs.Has(gvr.String())
 }
 
 func (m *DiscoveryManager) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -213,11 +209,9 @@ func (m *DiscoveryManager) rebuildClusterDiscoveryAPI(cluster string) {
 
 	apigroups := make([]metav1.APIGroup, 0, len(currentgroups))
 	for name, group := range currentgroups {
-		if name == "" {
-			continue
+		if name != "" {
+			apigroups = append(apigroups, group)
 		}
-
-		apigroups = append(apigroups, group)
 	}
 	sortAPIGroupByName(apigroups)
 
@@ -230,10 +224,9 @@ func (m *DiscoveryManager) rebuildGlobalDiscoveryAPI() {
 
 	apigroups := make([]metav1.APIGroup, 0, len(currentgroups))
 	for name, group := range currentgroups {
-		if name == "" {
-			continue
+		if name != "" {
+			apigroups = append(apigroups, group)
 		}
-		apigroups = append(apigroups, group)
 	}
 	sortAPIGroupByName(apigroups)
 

--- a/pkg/kubeapiserver/discovery/group.go
+++ b/pkg/kubeapiserver/discovery/group.go
@@ -105,10 +105,9 @@ func (h *clusterGroupDiscoveryHandler) removeClusterDiscoveryAPI(cluster string)
 
 	handlers := make(map[string]*groupDiscoveryHandler, len(currentHandlers)-1)
 	for name, handler := range currentHandlers {
-		if name == cluster {
-			continue
+		if name != cluster {
+			handlers[name] = handler
 		}
-		handlers[name] = handler
 	}
 	h.handlers.Store(handlers)
 }

--- a/pkg/kubeapiserver/discovery/group.go
+++ b/pkg/kubeapiserver/discovery/group.go
@@ -114,11 +114,11 @@ func (h *clusterGroupDiscoveryHandler) removeClusterDiscoveryAPI(cluster string)
 }
 
 func (h *clusterGroupDiscoveryHandler) rebuildGlobalDiscoveryAPI(source map[string]metav1.APIGroup) {
-	groupversions := make(map[schema.GroupVersion]struct{})
+	groupversions := sets.Set[schema.GroupVersion]{}
 	for _, handler := range h.handlers.Load().(map[string]*groupDiscoveryHandler) {
 		for group, apiGroup := range handler.groups {
 			for _, version := range apiGroup.Versions {
-				groupversions[schema.GroupVersion{Group: group, Version: version.Version}] = struct{}{}
+				groupversions.Insert(schema.GroupVersion{Group: group, Version: version.Version})
 			}
 		}
 	}
@@ -132,7 +132,7 @@ func (h *clusterGroupDiscoveryHandler) rebuildGlobalDiscoveryAPI(source map[stri
 	})
 }
 
-func buildAPIGroups(groupversions map[schema.GroupVersion]struct{}, source map[string]metav1.APIGroup) map[string]metav1.APIGroup {
+func buildAPIGroups(groupversions sets.Set[schema.GroupVersion], source map[string]metav1.APIGroup) map[string]metav1.APIGroup {
 	groups := sets.Set[string]{}
 	unsortedVersions := make(map[string][]metav1.GroupVersionForDiscovery)
 	for gv := range groupversions {

--- a/pkg/kubeapiserver/restmanager.go
+++ b/pkg/kubeapiserver/restmanager.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/handlers"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/restmapper"
@@ -153,10 +154,10 @@ func (m *RESTManager) LoadResources(infos ResourceInfoMap) map[schema.GroupResou
 		api := discovery.ResourceDiscoveryAPI{
 			Group:    gr.Group,
 			Resource: resource,
-			Versions: make(map[schema.GroupVersion]struct{}, len(versions)),
+			Versions: make(sets.Set[schema.GroupVersion], len(versions)),
 		}
 		for _, version := range versions {
-			api.Versions[version] = struct{}{}
+			api.Versions.Insert(version)
 
 			gvr := gr.WithVersion(version.Version)
 			if _, ok := restinfos[gvr]; !ok {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
