### PR TITLE
support openapi v2 for compatibility lower kubernete versions

### DIFF
--- a/cmd/apiserver/app/options/options.go
+++ b/cmd/apiserver/app/options/options.go
@@ -100,6 +100,10 @@ func (o *ClusterPediaServerOptions) Config() (*apiserver.Config, error) {
 
 	genericConfig := genericapiserver.NewRecommendedConfig(apiserver.Codecs)
 
+	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(apiserver.Scheme))
+	genericConfig.OpenAPIConfig.Info.Title = "clusterpedia apiserver"
+	genericConfig.OpenAPIConfig.Info.Version = ""
+
 	genericConfig.OpenAPIV3Config = genericapiserver.DefaultOpenAPIV3Config(generatedopenapi.GetOpenAPIDefinitions, openapinamer.NewDefinitionNamer(apiserver.Scheme))
 	genericConfig.OpenAPIV3Config.Info.Title = "clusterpedia apiserver"
 	genericConfig.OpenAPIV3Config.Info.Version = ""


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
kind feature
/kind flake

-->

**What this PR does / why we need it**:

If we want to run clusterpedia in low kubernete version , the kubernete apiserver will output error logs.

```
E1109 11:09:21.665110       1 controller.go:116] loading OpenAPI spec for "v1beta1.clusterpedia.io" failed with: OpenAPI spec does not exist
I1109 11:09:21.665131       1 controller.go:129] OpenAPI AggregationController: action for item v1beta1.clusterpedia.io: Rate Limited Requeue.  
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
