### PR TITLE
clustersynchro: handle each of the pages in the resource list stage

### DIFF
--- a/cmd/binding-apiserver/app/binding_apiserver.go
+++ b/cmd/binding-apiserver/app/binding_apiserver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/clusterpedia-io/clusterpedia/pkg/generated/clientset/versioned"
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
 	"github.com/clusterpedia-io/clusterpedia/pkg/synchromanager"
+	"github.com/clusterpedia-io/clusterpedia/pkg/synchromanager/clustersynchro"
 	clusterpediafeature "github.com/clusterpedia-io/clusterpedia/pkg/utils/feature"
 	"github.com/clusterpedia-io/clusterpedia/pkg/version/verflag"
 )
@@ -56,7 +57,7 @@ func NewClusterPediaServerCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			synchromanager := synchromanager.NewManager(crdclient, config.StorageFactory, nil)
+			synchromanager := synchromanager.NewManager(crdclient, config.StorageFactory, clustersynchro.ClusterSyncConfig{})
 			go synchromanager.Run(1, ctx.Done())
 
 			server, err := completedConfig.New()

--- a/cmd/clustersynchro-manager/app/config/config.go
+++ b/cmd/clustersynchro-manager/app/config/config.go
@@ -9,6 +9,7 @@ import (
 	kubestatemetrics "github.com/clusterpedia-io/clusterpedia/pkg/kube_state_metrics"
 	metrics "github.com/clusterpedia-io/clusterpedia/pkg/metrics"
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
+	"github.com/clusterpedia-io/clusterpedia/pkg/synchromanager/clustersynchro"
 )
 
 type Config struct {
@@ -19,8 +20,8 @@ type Config struct {
 	WorkerNumber            int
 	MetricsServerConfig     metrics.Config
 	KubeMetricsServerConfig *kubestatemetrics.ServerConfig
-	MetricsStoreBuilder     *kubestatemetrics.MetricsStoreBuilder
 	StorageFactory          storage.StorageFactory
+	ClusterSyncConfig       clustersynchro.ClusterSyncConfig
 
 	LeaderElection   componentbaseconfig.LeaderElectionConfiguration
 	ClientConnection componentbaseconfig.ClientConnectionConfiguration

--- a/cmd/clustersynchro-manager/app/synchro.go
+++ b/cmd/clustersynchro-manager/app/synchro.go
@@ -85,7 +85,7 @@ func NewClusterSynchroManagerCommand(ctx context.Context) *cobra.Command {
 }
 
 func Run(ctx context.Context, c *config.Config) error {
-	synchromanager := synchromanager.NewManager(c.CRDClient, c.StorageFactory, c.MetricsStoreBuilder)
+	synchromanager := synchromanager.NewManager(c.CRDClient, c.StorageFactory, c.ClusterSyncConfig)
 
 	go func() {
 		metrics.RunServer(c.MetricsServerConfig)

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -58,3 +58,14 @@ else
   echo "the file 'reflector.go' in vendor has been changed, please update the 'cache/.reflector.go' and 'reflector.go' in the pkg/synchromanager/clustersynchro/informer"
   exit 1
 fi
+
+pager=0
+diff vendor/k8s.io/client-go/tools/pager/pager.go pkg/synchromanager/clustersynchro/informer/pager/.pager.go.copy || pager=$?
+
+if [[ $pager -eq 0 ]]
+then
+  echo "'pager.go' is up to date."
+else
+  echo "the file 'pager.go' in vendor has been changed, please update the '.pager.go.copy' and 'pager.go' in the pkg/synchromanager/clustersynchro/informer/pager"
+  exit 1
+fi

--- a/pkg/synchromanager/clustersynchro/informer/named_controller.go
+++ b/pkg/synchromanager/clustersynchro/informer/named_controller.go
@@ -49,6 +49,15 @@ type Config struct {
 
 	// WatchListPageSize is the requested chunk size of initial and relist watch lists.
 	WatchListPageSize int64
+
+	// StreamHandle of paginated list, resources within a pager will be processed
+	// as soon as possible instead of waiting until all resources are pulled before calling the ResourceHandler.
+	StreamHandleForPaginatedList bool
+
+	// Force paging, Reflector will sometimes use APIServer's cache,
+	// even if paging is specified APIServer will return all resources for performance,
+	// then it will skip Reflector's streaming memory optimization.
+	ForcePaginatedList bool
 }
 
 type controller struct {
@@ -86,6 +95,8 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 	}
 	r.ShouldResync = c.config.ShouldResync
 	r.WatchListPageSize = c.config.WatchListPageSize
+	r.ForcePaginatedList = c.config.ForcePaginatedList
+	r.StreamHandleForPaginatedList = c.config.StreamHandleForPaginatedList
 
 	c.reflectorMutex.Lock()
 	c.reflector = r

--- a/pkg/synchromanager/clustersynchro/informer/named_controller.go
+++ b/pkg/synchromanager/clustersynchro/informer/named_controller.go
@@ -131,7 +131,7 @@ func (c *controller) HasSynced() bool {
 	if c.queue == nil {
 		return false
 	}
-	return c.queue.HasSynced()
+	return c.queue.HasSynced() && c.reflector.HasInitializedSynced()
 }
 
 func (c *controller) LastSyncResourceVersion() string {

--- a/pkg/synchromanager/clustersynchro/informer/pager/.pager.go.copy
+++ b/pkg/synchromanager/clustersynchro/informer/pager/.pager.go.copy
@@ -1,0 +1,289 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pager
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const defaultPageSize = 500
+const defaultPageBufferSize = 10
+
+// ListPageFunc returns a list object for the given list options.
+type ListPageFunc func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error)
+
+// SimplePageFunc adapts a context-less list function into one that accepts a context.
+func SimplePageFunc(fn func(opts metav1.ListOptions) (runtime.Object, error)) ListPageFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return fn(opts)
+	}
+}
+
+// ListPager assists client code in breaking large list queries into multiple
+// smaller chunks of PageSize or smaller. PageFn is expected to accept a
+// metav1.ListOptions that supports paging and return a list. The pager does
+// not alter the field or label selectors on the initial options list.
+type ListPager struct {
+	PageSize int64
+	PageFn   ListPageFunc
+
+	FullListIfExpired bool
+
+	// Number of pages to buffer
+	PageBufferSize int32
+}
+
+// New creates a new pager from the provided pager function using the default
+// options. It will fall back to a full list if an expiration error is encountered
+// as a last resort.
+func New(fn ListPageFunc) *ListPager {
+	return &ListPager{
+		PageSize:          defaultPageSize,
+		PageFn:            fn,
+		FullListIfExpired: true,
+		PageBufferSize:    defaultPageBufferSize,
+	}
+}
+
+// TODO: introduce other types of paging functions - such as those that retrieve from a list
+// of namespaces.
+
+// List returns a single list object, but attempts to retrieve smaller chunks from the
+// server to reduce the impact on the server. If the chunk attempt fails, it will load
+// the full list instead. The Limit field on options, if unset, will default to the page size.
+//
+// If items in the returned list are retained for different durations, and you want to avoid
+// retaining the whole slice returned by p.PageFn as long as any item is referenced,
+// use ListWithAlloc instead.
+func (p *ListPager) List(ctx context.Context, options metav1.ListOptions) (runtime.Object, bool, error) {
+	return p.list(ctx, options, false)
+}
+
+// ListWithAlloc works like List, but avoids retaining references to the items slice returned by p.PageFn.
+// It does this by making a shallow copy of non-pointer items in the slice returned by p.PageFn.
+//
+// If the items in the returned list are not retained, or are retained for the same duration, use List instead for memory efficiency.
+func (p *ListPager) ListWithAlloc(ctx context.Context, options metav1.ListOptions) (runtime.Object, bool, error) {
+	return p.list(ctx, options, true)
+}
+
+func (p *ListPager) list(ctx context.Context, options metav1.ListOptions, allocNew bool) (runtime.Object, bool, error) {
+	if options.Limit == 0 {
+		options.Limit = p.PageSize
+	}
+	requestedResourceVersion := options.ResourceVersion
+	requestedResourceVersionMatch := options.ResourceVersionMatch
+	var list *metainternalversion.List
+	paginatedResult := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, paginatedResult, ctx.Err()
+		default:
+		}
+
+		obj, err := p.PageFn(ctx, options)
+		if err != nil {
+			// Only fallback to full list if an "Expired" errors is returned, FullListIfExpired is true, and
+			// the "Expired" error occurred in page 2 or later (since full list is intended to prevent a pager.List from
+			// failing when the resource versions is established by the first page request falls out of the compaction
+			// during the subsequent list requests).
+			if !errors.IsResourceExpired(err) || !p.FullListIfExpired || options.Continue == "" {
+				return nil, paginatedResult, err
+			}
+			// the list expired while we were processing, fall back to a full list at
+			// the requested ResourceVersion.
+			options.Limit = 0
+			options.Continue = ""
+			options.ResourceVersion = requestedResourceVersion
+			options.ResourceVersionMatch = requestedResourceVersionMatch
+			result, err := p.PageFn(ctx, options)
+			return result, paginatedResult, err
+		}
+		m, err := meta.ListAccessor(obj)
+		if err != nil {
+			return nil, paginatedResult, fmt.Errorf("returned object must be a list: %v", err)
+		}
+
+		// exit early and return the object we got if we haven't processed any pages
+		if len(m.GetContinue()) == 0 && list == nil {
+			return obj, paginatedResult, nil
+		}
+
+		// initialize the list and fill its contents
+		if list == nil {
+			list = &metainternalversion.List{Items: make([]runtime.Object, 0, options.Limit+1)}
+			list.ResourceVersion = m.GetResourceVersion()
+			list.SelfLink = m.GetSelfLink()
+		}
+		eachListItemFunc := meta.EachListItem
+		if allocNew {
+			eachListItemFunc = meta.EachListItemWithAlloc
+		}
+		if err := eachListItemFunc(obj, func(obj runtime.Object) error {
+			list.Items = append(list.Items, obj)
+			return nil
+		}); err != nil {
+			return nil, paginatedResult, err
+		}
+
+		// if we have no more items, return the list
+		if len(m.GetContinue()) == 0 {
+			return list, paginatedResult, nil
+		}
+
+		// set the next loop up
+		options.Continue = m.GetContinue()
+		// Clear the ResourceVersion(Match) on the subsequent List calls to avoid the
+		// `specifying resource version is not allowed when using continue` error.
+		// See https://github.com/kubernetes/kubernetes/issues/85221#issuecomment-553748143.
+		options.ResourceVersion = ""
+		options.ResourceVersionMatch = ""
+		// At this point, result is already paginated.
+		paginatedResult = true
+	}
+}
+
+// EachListItem fetches runtime.Object items using this ListPager and invokes fn on each item. If
+// fn returns an error, processing stops and that error is returned. If fn does not return an error,
+// any error encountered while retrieving the list from the server is returned. If the context
+// cancels or times out, the context error is returned. Since the list is retrieved in paginated
+// chunks, an "Expired" error (metav1.StatusReasonExpired) may be returned if the pagination list
+// requests exceed the expiration limit of the apiserver being called.
+//
+// Items are retrieved in chunks from the server to reduce the impact on the server with up to
+// ListPager.PageBufferSize chunks buffered concurrently in the background.
+//
+// If items passed to fn are retained for different durations, and you want to avoid
+// retaining the whole slice returned by p.PageFn as long as any item is referenced,
+// use EachListItemWithAlloc instead.
+func (p *ListPager) EachListItem(ctx context.Context, options metav1.ListOptions, fn func(obj runtime.Object) error) error {
+	return p.eachListChunkBuffered(ctx, options, func(obj runtime.Object) error {
+		return meta.EachListItem(obj, fn)
+	})
+}
+
+// EachListItemWithAlloc works like EachListItem, but avoids retaining references to the items slice returned by p.PageFn.
+// It does this by making a shallow copy of non-pointer items in the slice returned by p.PageFn.
+//
+// If the items passed to fn are not retained, or are retained for the same duration, use EachListItem instead for memory efficiency.
+func (p *ListPager) EachListItemWithAlloc(ctx context.Context, options metav1.ListOptions, fn func(obj runtime.Object) error) error {
+	return p.eachListChunkBuffered(ctx, options, func(obj runtime.Object) error {
+		return meta.EachListItemWithAlloc(obj, fn)
+	})
+}
+
+// eachListChunkBuffered fetches runtimeObject list chunks using this ListPager and invokes fn on
+// each list chunk.  If fn returns an error, processing stops and that error is returned. If fn does
+// not return an error, any error encountered while retrieving the list from the server is
+// returned. If the context cancels or times out, the context error is returned. Since the list is
+// retrieved in paginated chunks, an "Expired" error (metav1.StatusReasonExpired) may be returned if
+// the pagination list requests exceed the expiration limit of the apiserver being called.
+//
+// Up to ListPager.PageBufferSize chunks are buffered concurrently in the background.
+func (p *ListPager) eachListChunkBuffered(ctx context.Context, options metav1.ListOptions, fn func(obj runtime.Object) error) error {
+	if p.PageBufferSize < 0 {
+		return fmt.Errorf("ListPager.PageBufferSize must be >= 0, got %d", p.PageBufferSize)
+	}
+
+	// Ensure background goroutine is stopped if this call exits before all list items are
+	// processed. Cancelation error from this deferred cancel call is never returned to caller;
+	// either the list result has already been sent to bgResultC or the fn error is returned and
+	// the cancelation error is discarded.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	chunkC := make(chan runtime.Object, p.PageBufferSize)
+	bgResultC := make(chan error, 1)
+	go func() {
+		defer utilruntime.HandleCrash()
+
+		var err error
+		defer func() {
+			close(chunkC)
+			bgResultC <- err
+		}()
+		err = p.eachListChunk(ctx, options, func(chunk runtime.Object) error {
+			select {
+			case chunkC <- chunk: // buffer the chunk, this can block
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			return nil
+		})
+	}()
+
+	for o := range chunkC {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		err := fn(o)
+		if err != nil {
+			return err // any fn error should be returned immediately
+		}
+	}
+	// promote the results of our background goroutine to the foreground
+	return <-bgResultC
+}
+
+// eachListChunk fetches runtimeObject list chunks using this ListPager and invokes fn on each list
+// chunk. If fn returns an error, processing stops and that error is returned. If fn does not return
+// an error, any error encountered while retrieving the list from the server is returned. If the
+// context cancels or times out, the context error is returned. Since the list is retrieved in
+// paginated chunks, an "Expired" error (metav1.StatusReasonExpired) may be returned if the
+// pagination list requests exceed the expiration limit of the apiserver being called.
+func (p *ListPager) eachListChunk(ctx context.Context, options metav1.ListOptions, fn func(obj runtime.Object) error) error {
+	if options.Limit == 0 {
+		options.Limit = p.PageSize
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		obj, err := p.PageFn(ctx, options)
+		if err != nil {
+			return err
+		}
+		m, err := meta.ListAccessor(obj)
+		if err != nil {
+			return fmt.Errorf("returned object must be a list: %v", err)
+		}
+		if err := fn(obj); err != nil {
+			return err
+		}
+		// if we have no more items, return.
+		if len(m.GetContinue()) == 0 {
+			return nil
+		}
+		// set the next loop up
+		options.Continue = m.GetContinue()
+	}
+}

--- a/pkg/synchromanager/clustersynchro/informer/pager/pager.go
+++ b/pkg/synchromanager/clustersynchro/informer/pager/pager.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pager
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const defaultPageSize = 500
+const defaultPageBufferSize = 10
+
+// ListPageFunc returns a list object for the given list options.
+type ListPageFunc func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error)
+
+// SimplePageFunc adapts a context-less list function into one that accepts a context.
+func SimplePageFunc(fn func(opts metav1.ListOptions) (runtime.Object, error)) ListPageFunc {
+	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return fn(opts)
+	}
+}
+
+// ListPager assists client code in breaking large list queries into multiple
+// smaller chunks of PageSize or smaller. PageFn is expected to accept a
+// metav1.ListOptions that supports paging and return a list. The pager does
+// not alter the field or label selectors on the initial options list.
+type ListPager struct {
+	PageSize int64
+	PageFn   ListPageFunc
+
+	FullListIfExpired bool
+
+	// Number of pages to buffer
+	PageBufferSize int32
+}
+
+// New creates a new pager from the provided pager function using the default
+// options. It will fall back to a full list if an expiration error is encountered
+// as a last resort.
+func New(fn ListPageFunc) *ListPager {
+	return &ListPager{
+		PageSize:          defaultPageSize,
+		PageFn:            fn,
+		FullListIfExpired: true,
+		PageBufferSize:    defaultPageBufferSize,
+	}
+}
+
+// TODO: introduce other types of paging functions - such as those that retrieve from a list
+// of namespaces.
+
+// List returns a single list object, but attempts to retrieve smaller chunks from the
+// server to reduce the impact on the server. If the chunk attempt fails, it will load
+// the full list instead. The Limit field on options, if unset, will default to the page size.
+//
+// If items in the returned list are retained for different durations, and you want to avoid
+// retaining the whole slice returned by p.PageFn as long as any item is referenced,
+// use ListWithAlloc instead.
+func (p *ListPager) List(ctx context.Context, options metav1.ListOptions) (runtime.Object, bool, error) {
+	return p.list(ctx, options, false)
+}
+
+// ListWithAlloc works like List, but avoids retaining references to the items slice returned by p.PageFn.
+// It does this by making a shallow copy of non-pointer items in the slice returned by p.PageFn.
+//
+// If the items in the returned list are not retained, or are retained for the same duration, use List instead for memory efficiency.
+func (p *ListPager) ListWithAlloc(ctx context.Context, options metav1.ListOptions) (runtime.Object, bool, error) {
+	return p.list(ctx, options, true)
+}
+
+func (p *ListPager) list(ctx context.Context, options metav1.ListOptions, allocNew bool) (runtime.Object, bool, error) {
+	if options.Limit == 0 {
+		options.Limit = p.PageSize
+	}
+	requestedResourceVersion := options.ResourceVersion
+	requestedResourceVersionMatch := options.ResourceVersionMatch
+	var list *metainternalversion.List
+	paginatedResult := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, paginatedResult, ctx.Err()
+		default:
+		}
+
+		obj, err := p.PageFn(ctx, options)
+		if err != nil {
+			// Only fallback to full list if an "Expired" errors is returned, FullListIfExpired is true, and
+			// the "Expired" error occurred in page 2 or later (since full list is intended to prevent a pager.List from
+			// failing when the resource versions is established by the first page request falls out of the compaction
+			// during the subsequent list requests).
+			if !errors.IsResourceExpired(err) || !p.FullListIfExpired || options.Continue == "" {
+				return nil, paginatedResult, err
+			}
+			// the list expired while we were processing, fall back to a full list at
+			// the requested ResourceVersion.
+			options.Limit = 0
+			options.Continue = ""
+			options.ResourceVersion = requestedResourceVersion
+			options.ResourceVersionMatch = requestedResourceVersionMatch
+			result, err := p.PageFn(ctx, options)
+			return result, paginatedResult, err
+		}
+		m, err := meta.ListAccessor(obj)
+		if err != nil {
+			return nil, paginatedResult, fmt.Errorf("returned object must be a list: %v", err)
+		}
+
+		// exit early and return the object we got if we haven't processed any pages
+		if len(m.GetContinue()) == 0 && list == nil {
+			return obj, paginatedResult, nil
+		}
+
+		// initialize the list and fill its contents
+		if list == nil {
+			list = &metainternalversion.List{Items: make([]runtime.Object, 0, options.Limit+1)}
+			list.ResourceVersion = m.GetResourceVersion()
+			list.SelfLink = m.GetSelfLink()
+		}
+		eachListItemFunc := meta.EachListItem
+		if allocNew {
+			eachListItemFunc = meta.EachListItemWithAlloc
+		}
+		if err := eachListItemFunc(obj, func(obj runtime.Object) error {
+			list.Items = append(list.Items, obj)
+			return nil
+		}); err != nil {
+			return nil, paginatedResult, err
+		}
+
+		// if we have no more items, return the list
+		if len(m.GetContinue()) == 0 {
+			return list, paginatedResult, nil
+		}
+
+		// set the next loop up
+		options.Continue = m.GetContinue()
+		// Clear the ResourceVersion(Match) on the subsequent List calls to avoid the
+		// `specifying resource version is not allowed when using continue` error.
+		// See https://github.com/kubernetes/kubernetes/issues/85221#issuecomment-553748143.
+		options.ResourceVersion = ""
+		options.ResourceVersionMatch = ""
+		// At this point, result is already paginated.
+		paginatedResult = true
+	}
+}
+
+// EachListItem fetches runtime.Object items using this ListPager and invokes fn on each item. If
+// fn returns an error, processing stops and that error is returned. If fn does not return an error,
+// any error encountered while retrieving the list from the server is returned. If the context
+// cancels or times out, the context error is returned. Since the list is retrieved in paginated
+// chunks, an "Expired" error (metav1.StatusReasonExpired) may be returned if the pagination list
+// requests exceed the expiration limit of the apiserver being called.
+//
+// Items are retrieved in chunks from the server to reduce the impact on the server with up to
+// ListPager.PageBufferSize chunks buffered concurrently in the background.
+//
+// If items passed to fn are retained for different durations, and you want to avoid
+// retaining the whole slice returned by p.PageFn as long as any item is referenced,
+// use EachListItemWithAlloc instead.
+func (p *ListPager) EachListItem(ctx context.Context, options metav1.ListOptions, fn func(obj runtime.Object) error) error {
+	return p.eachListChunkBuffered(ctx, options, func(obj runtime.Object) error {
+		return meta.EachListItem(obj, fn)
+	})
+}
+
+// EachListItemWithAlloc works like EachListItem, but avoids retaining references to the items slice returned by p.PageFn.
+// It does this by making a shallow copy of non-pointer items in the slice returned by p.PageFn.
+//
+// If the items passed to fn are not retained, or are retained for the same duration, use EachListItem instead for memory efficiency.
+func (p *ListPager) EachListItemWithAlloc(ctx context.Context, options metav1.ListOptions, fn func(obj runtime.Object) error) error {
+	return p.eachListChunkBuffered(ctx, options, func(obj runtime.Object) error {
+		return meta.EachListItemWithAlloc(obj, fn)
+	})
+}
+
+// eachListChunkBuffered fetches runtimeObject list chunks using this ListPager and invokes fn on
+// each list chunk.  If fn returns an error, processing stops and that error is returned. If fn does
+// not return an error, any error encountered while retrieving the list from the server is
+// returned. If the context cancels or times out, the context error is returned. Since the list is
+// retrieved in paginated chunks, an "Expired" error (metav1.StatusReasonExpired) may be returned if
+// the pagination list requests exceed the expiration limit of the apiserver being called.
+//
+// Up to ListPager.PageBufferSize chunks are buffered concurrently in the background.
+func (p *ListPager) eachListChunkBuffered(ctx context.Context, options metav1.ListOptions, fn func(obj runtime.Object) error) error {
+	if p.PageBufferSize < 0 {
+		return fmt.Errorf("ListPager.PageBufferSize must be >= 0, got %d", p.PageBufferSize)
+	}
+
+	// Ensure background goroutine is stopped if this call exits before all list items are
+	// processed. Cancelation error from this deferred cancel call is never returned to caller;
+	// either the list result has already been sent to bgResultC or the fn error is returned and
+	// the cancelation error is discarded.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	chunkC := make(chan runtime.Object, p.PageBufferSize)
+	bgResultC := make(chan error, 1)
+	go func() {
+		defer utilruntime.HandleCrash()
+
+		var err error
+		defer func() {
+			close(chunkC)
+			bgResultC <- err
+		}()
+		err = p.eachListChunk(ctx, options, func(chunk runtime.Object) error {
+			select {
+			case chunkC <- chunk: // buffer the chunk, this can block
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			return nil
+		})
+	}()
+
+	for o := range chunkC {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		err := fn(o)
+		if err != nil {
+			return err // any fn error should be returned immediately
+		}
+	}
+	// promote the results of our background goroutine to the foreground
+	return <-bgResultC
+}
+
+// eachListChunk fetches runtimeObject list chunks using this ListPager and invokes fn on each list
+// chunk. If fn returns an error, processing stops and that error is returned. If fn does not return
+// an error, any error encountered while retrieving the list from the server is returned. If the
+// context cancels or times out, the context error is returned. Since the list is retrieved in
+// paginated chunks, an "Expired" error (metav1.StatusReasonExpired) may be returned if the
+// pagination list requests exceed the expiration limit of the apiserver being called.
+func (p *ListPager) eachListChunk(ctx context.Context, options metav1.ListOptions, fn func(obj runtime.Object) error) error {
+	if options.Limit == 0 {
+		options.Limit = p.PageSize
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		obj, err := p.PageFn(ctx, options)
+		if err != nil {
+			return err
+		}
+		m, err := meta.ListAccessor(obj)
+		if err != nil {
+			return fmt.Errorf("returned object must be a list: %v", err)
+		}
+		if err := fn(obj); err != nil {
+			return err
+		}
+		// if we have no more items, return.
+		if len(m.GetContinue()) == 0 {
+			return nil
+		}
+		// set the next loop up
+		options.Continue = m.GetContinue()
+	}
+}

--- a/pkg/synchromanager/clustersynchro/informer/pager/result_stream.go
+++ b/pkg/synchromanager/clustersynchro/informer/pager/result_stream.go
@@ -1,0 +1,20 @@
+package pager
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type resultStream int
+
+const resultStreamKey resultStream = iota
+
+func WithResultStream(parent context.Context, ch chan runtime.Object) context.Context {
+	return context.WithValue(parent, resultStreamKey, ch)
+}
+
+func ResultStream(ctx context.Context) chan runtime.Object {
+	ch, _ := ctx.Value(resultStreamKey).(chan runtime.Object)
+	return ch
+}

--- a/pkg/synchromanager/clustersynchro/informer/reflector.go
+++ b/pkg/synchromanager/clustersynchro/informer/reflector.go
@@ -22,10 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/pager"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/trace"
+
+	clspager "github.com/clusterpedia-io/clusterpedia/pkg/synchromanager/clustersynchro/informer/pager"
 )
 
 const defaultExpectedTypeName = "<unspecified>"
@@ -86,6 +87,15 @@ type Reflector struct {
 	WatchListPageSize int64
 	// Called whenever the ListAndWatch drops the connection with an error.
 	watchErrorHandler WatchErrorHandler
+
+	// StreamHandle of paginated list, resources within a pager will be processed
+	// as soon as possible instead of waiting until all resources are pulled before calling the ResourceHandler.
+	StreamHandleForPaginatedList bool
+
+	// Force paging, Reflector will sometimes use APIServer's cache,
+	// even if paging is specified APIServer will return all resources for performance,
+	// then it will skip Reflector's streaming memory optimization.
+	ForcePaginatedList bool
 }
 
 // ResourceVersionUpdater is an interface that allows store implementation to
@@ -349,6 +359,7 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 	initTrace := trace.New("Reflector ListAndWatch", trace.Field{Key: "name", Value: r.name})
 	defer initTrace.LogIfLong(10 * time.Second)
 	var list runtime.Object
+	var itemKeys []interface{}
 	var paginatedResult bool
 	var err error
 	listCh := make(chan struct{}, 1)
@@ -361,7 +372,7 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 		}()
 		// Attempt to gather list in chunks, if supported by listerWatcher, if not, the first
 		// list request will return the full response.
-		pager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
+		pager := clspager.New(clspager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
 			return r.listerWatcher.List(opts)
 		}))
 		switch {
@@ -387,7 +398,12 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 			pager.PageSize = 0
 		}
 
-		list, paginatedResult, err = pager.List(context.Background(), options)
+		if r.StreamHandleForPaginatedList {
+			list, itemKeys, paginatedResult, err = r.listWithResultStream(context.Background(), pager, options)
+		} else {
+			list, paginatedResult, err = pager.List(context.Background(), options)
+		}
+
 		if isExpiredError(err) || isTooLargeResourceVersionError(err) {
 			r.setIsLastSyncResourceVersionUnavailable(true)
 			// Retry immediately if the resource version used to list is unavailable.
@@ -396,7 +412,13 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 			// resource version it is listing at is expired or the cache may not yet be synced to the provided
 			// resource version. So we need to fallback to resourceVersion="" in all to recover and ensure
 			// the reflector makes forward progress.
-			list, paginatedResult, err = pager.List(context.Background(), metav1.ListOptions{ResourceVersion: r.relistResourceVersion()})
+
+			options := metav1.ListOptions{ResourceVersion: r.relistResourceVersion()}
+			if r.StreamHandleForPaginatedList {
+				list, itemKeys, paginatedResult, err = r.listWithResultStream(context.Background(), pager, options)
+			} else {
+				list, paginatedResult, err = pager.List(context.Background(), options)
+			}
 		}
 		close(listCh)
 	}()
@@ -434,18 +456,47 @@ func (r *Reflector) list(stopCh <-chan struct{}) error {
 	}
 	resourceVersion = listMetaInterface.GetResourceVersion()
 	initTrace.Step("Resource version extracted")
-	items, err := meta.ExtractList(list)
-	if err != nil {
-		return fmt.Errorf("unable to understand list result %#v (%v)", list, err)
+
+	if len(itemKeys) != 0 {
+		if err := r.syncWithKeys(itemKeys, resourceVersion); err != nil {
+			return fmt.Errorf("unable to sync list result: %v", err)
+		}
+	} else {
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			return fmt.Errorf("unable to understand list result %#v (%v)", list, err)
+		}
+		initTrace.Step("Objects extracted")
+		if err := r.syncWith(items, resourceVersion); err != nil {
+			return fmt.Errorf("unable to sync list result: %v", err)
+		}
 	}
-	initTrace.Step("Objects extracted")
-	if err := r.syncWith(items, resourceVersion); err != nil {
-		return fmt.Errorf("unable to sync list result: %v", err)
-	}
+
 	initTrace.Step("SyncWith done")
 	r.setLastSyncResourceVersion(resourceVersion)
 	initTrace.Step("Resource version updated")
 	return nil
+}
+
+func (r *Reflector) listWithResultStream(ctx context.Context, pager *clspager.ListPager, options metav1.ListOptions) (
+	list runtime.Object, itemKeys []interface{}, paginatedResult bool, err error,
+) {
+	ch := make(chan runtime.Object, 10)
+	go func() {
+		list, paginatedResult, err = pager.List(clspager.WithResultStream(ctx, ch), options)
+	}()
+
+	var key string
+	for obj := range ch {
+		if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+			return
+		}
+		if err = r.store.Add(obj); err != nil {
+			return
+		}
+		itemKeys = append(itemKeys, cache.ExplicitKey(key))
+	}
+	return
 }
 
 // syncWith replaces the store's items with the given list.
@@ -455,6 +506,10 @@ func (r *Reflector) syncWith(items []runtime.Object, resourceVersion string) err
 		found = append(found, item)
 	}
 	return r.store.Replace(found, resourceVersion)
+}
+
+func (r *Reflector) syncWithKeys(keys []interface{}, resourceVersion string) error {
+	return r.store.Replace(keys, resourceVersion)
 }
 
 // watchHandler watches w and sets setLastSyncResourceVersion
@@ -578,6 +633,9 @@ func (r *Reflector) relistResourceVersion() string {
 		return ""
 	}
 	if r.lastSyncResourceVersion == "" {
+		if r.ForcePaginatedList {
+			return ""
+		}
 		// For performance reasons, initial list performed by reflector uses "0" as resource version to allow it to
 		// be served from the watch cache if it is enabled.
 		return "0"

--- a/pkg/synchromanager/clustersynchro/informer/resourceversion_informer.go
+++ b/pkg/synchromanager/clustersynchro/informer/resourceversion_informer.go
@@ -19,7 +19,21 @@ type resourceVersionInformer struct {
 	listerWatcher cache.ListerWatcher
 }
 
-func NewResourceVersionInformer(name string, lw cache.ListerWatcher, storage *ResourceVersionStorage, exampleObject runtime.Object, handler ResourceEventHandler, errorHandler WatchErrorHandler, extraStore ExtraStore) ResourceVersionInformer {
+type InformerConfig struct {
+	cache.ListerWatcher
+	Storage *ResourceVersionStorage
+
+	ExampleObject runtime.Object
+	Handler       ResourceEventHandler
+	ErrorHandler  WatchErrorHandler
+	ExtraStore    ExtraStore
+
+	WatchListPageSize            int64
+	ForcePaginatedList           bool
+	StreamHandleForPaginatedList bool
+}
+
+func NewResourceVersionInformer(name string, config InformerConfig) ResourceVersionInformer {
 	if name == "" {
 		panic("name is required")
 	}
@@ -27,9 +41,9 @@ func NewResourceVersionInformer(name string, lw cache.ListerWatcher, storage *Re
 	// storage: NewResourceVersionStorage(cache.DeletionHandlingMetaNamespaceKeyFunc),
 	informer := &resourceVersionInformer{
 		name:          name,
-		listerWatcher: lw,
-		storage:       storage,
-		handler:       handler,
+		listerWatcher: config.ListerWatcher,
+		storage:       config.Storage,
+		handler:       config.Handler,
 	}
 
 	var queue cache.Queue = cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{
@@ -37,22 +51,26 @@ func NewResourceVersionInformer(name string, lw cache.ListerWatcher, storage *Re
 		KnownObjects:          informer.storage,
 		EmitDeltaTypeReplaced: true,
 	})
-	if extraStore != nil {
-		queue = &queueWithExtraStore{Queue: queue, extra: extraStore}
+	if config.ExtraStore != nil {
+		queue = &queueWithExtraStore{Queue: queue, extra: config.ExtraStore}
 	}
 
-	config := &Config{
-		ListerWatcher: lw,
-		ObjectType:    exampleObject,
-		RetryOnError:  false,
-		Process: func(obj interface{}, isInInitialList bool) error {
-			deltas := obj.(cache.Deltas)
-			return informer.HandleDeltas(deltas, isInInitialList)
+	informer.controller = NewNamedController(informer.name,
+		&Config{
+			ListerWatcher: config.ListerWatcher,
+			ObjectType:    config.ExampleObject,
+			RetryOnError:  false,
+			Process: func(obj interface{}, isInInitialList bool) error {
+				deltas := obj.(cache.Deltas)
+				return informer.HandleDeltas(deltas, isInInitialList)
+			},
+			Queue:                        queue,
+			WatchErrorHandler:            config.ErrorHandler,
+			WatchListPageSize:            config.WatchListPageSize,
+			ForcePaginatedList:           config.ForcePaginatedList,
+			StreamHandleForPaginatedList: config.StreamHandleForPaginatedList,
 		},
-		Queue:             queue,
-		WatchErrorHandler: errorHandler,
-	}
-	informer.controller = NewNamedController(informer.name, config)
+	)
 	return informer
 }
 
@@ -68,6 +86,10 @@ func (informer *resourceVersionInformer) HandleDeltas(deltas cache.Deltas, isInI
 	for _, d := range deltas {
 		switch d.Type {
 		case cache.Replaced, cache.Added, cache.Updated:
+			if _, ok := d.Object.(cache.ExplicitKey); ok {
+				return nil
+			}
+
 			version, exists, err := informer.storage.Get(d.Object)
 			if err != nil {
 				return err

--- a/pkg/synchromanager/features/features.go
+++ b/pkg/synchromanager/features/features.go
@@ -42,9 +42,25 @@ const (
 	AllowSyncAllResources featuregate.Feature = "AllowSyncAllResources"
 
 	// HealthCheckerWithStandaloneTCP is a feature gate for the cluster health checker to use standalone tcp
+	//
 	// owner: @iceber
 	// alpha: v0.6.0
 	HealthCheckerWithStandaloneTCP featuregate.Feature = "HealthCheckerWithStandaloneTCP"
+
+	// ForcePaginatedListForResourceSync is a feature gate for ResourceSync's reflector to force paginated list,
+	// reflector will sometimes use APIServer's cache, even if paging is specified APIServer will return all resources for performance,
+	// then it will skip Reflector's streaming memory optimization.
+	//
+	// owner: @iceber
+	// alpha: v0.8.0
+	ForcePaginatedListForResourceSync featuregate.Feature = "ForcePaginatedListForResourceSync"
+
+	// StreamHandlePaginatedListForResourceSync is a feature gate for ResourceSync's reflector to handle echo paginated resources,
+	// resources within a pager will be processed as soon as possible instead of waiting until all resources are pulled before calling the ResourceHandler.
+	//
+	// owner: @iceber
+	// alpha: v0.8.0
+	StreamHandlePaginatedListForResourceSync featuregate.Feature = "StreamHandlePaginatedListForResourceSync"
 )
 
 func init() {
@@ -59,4 +75,7 @@ var defaultClusterSynchroManagerFeatureGates = map[featuregate.Feature]featurega
 	AllowSyncAllCustomResources:    {Default: false, PreRelease: featuregate.Alpha},
 	AllowSyncAllResources:          {Default: false, PreRelease: featuregate.Alpha},
 	HealthCheckerWithStandaloneTCP: {Default: false, PreRelease: featuregate.Alpha},
+
+	ForcePaginatedListForResourceSync:        {Default: false, PreRelease: featuregate.Alpha},
+	StreamHandlePaginatedListForResourceSync: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
In List, the paged pull method is used, so the resources within each paging will be processed directly.
1. The resources in each page of the List are sent directly to the DeltaFIFO, and the ResourceHandler is notified to process the resources.
2. Before sending to DeltaFIFO, the key of each resource is saved to the itemKeys list.
3. after all paging pulls are complete, the resources are compared to those that will trigger the Delete event via DeltaFIFO.Replace(itemKeys).


Added two FeatureGates:
`StreamHandlePaginatedListForResourceSync`: stream handling of paged resources, resources within a pager will be processed as soon as possible instead of waiting until all resources are pulled before calling the ResourceHandler.
`ForcePaginatedListForResourceSync`: force paging, Reflector will sometimes use APIServer's cache, even if paging is specified APIServer will return all resources for performance, then it will skip Reflector's streaming memory optimization.

**`ForcePaginatedListForResourceSync` may put extra pressure on the imported cluster APIServer, please be careful to enable it**.

clustersynchro-manager add `--page-size` flags, you can control the page size of the List, the smaller the page size, the smaller the memory consumption, but may also generate more requests to APIServer.


**Which issue(s) this PR fixes**:
fix: https://github.com/clusterpedia-io/clusterpedia/issues/594

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
