### PR TITLE
fix build without tags and add building command printing

### DIFF
--- a/hack/builder-nocgo.sh
+++ b/hack/builder-nocgo.sh
@@ -18,8 +18,12 @@ function build_component() {
     LDFLAGS=${BUILD_LDFLAGS:-""}
     if [ -f ./ldflags.sh ]; then
         source ./ldflags.sh
+        LDFLAGS+=" $(extra_ldflags)"
     fi
+
+    set -x
 	CGO_ENABLED=0 go build -ldflags "${LDFLAGS}" -o ${OUTPUT_DIR}/bin/$1 ./cmd/$1
+    set +x
 }
 
 build_component $1

--- a/hack/builder.sh
+++ b/hack/builder.sh
@@ -91,6 +91,7 @@ function build_component() {
     local LDFLAGS=${BUILD_LDFLAGS:-""}
     if [ -f ${CLUSTERPEDIA_REPO}/ldflags.sh ]; then
         cd ${CLUSTERPEDIA_REPO} && source ./ldflags.sh
+        LDFLAGS+=" $(extra_ldflags)"
     fi
 
     if [[ "${GOOS}" == "linux" ]]; then
@@ -98,9 +99,11 @@ function build_component() {
         LDFLAGS+=" -extldflags -static"
     fi
 
+    set -x
     cd $TMP_CLUSTERPEDIA
     GOPATH=$TMP_GOPATH GO111MODULE=off CGO_ENABLED=1 CC_FOR_TARGET=$CC_FOR_TARGET CC=$CC \
         go build -tags "json1 $GOOS" -ldflags "${LDFLAGS}" -o $OUTPUT_DIR/bin/$1 ./cmd/$1
+    set +x
 }
 
 cleanup
@@ -161,9 +164,11 @@ function build_plugin() {
         cd ${PLUGIN_REPO} && source ./ldflags.sh
     fi
 
+    set -x
     cd $TMP_PLUGIN
     GOPATH=$TMP_GOPATH GO111MODULE=off CGO_ENABLED=1 CC_FOR_TARGET=$CC_FOR_TARGET CC=$CC \
         go build -ldflags "${LDFLAGS}" -buildmode=plugin -o $OUTPUT_DIR/plugins/$1
+    set +x
 }
 
 copy_plugin_repo

--- a/ldflags.sh
+++ b/ldflags.sh
@@ -1,42 +1,51 @@
 #!/usr/bin/env bash
 
-BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+set -o errexit
+set -o nounset
+set -o pipefail
 
-# Git information, used to set clusterpedia version
-GIT_VERSION=$(git describe --tags --dirty)
-GIT_COMMIT_HASH=$(git rev-parse HEAD)
+function extra_ldflags() {
+    BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
-GIT_TREESTATE="clean"
-GIT_DIFF=$(git diff --quiet >/dev/null 2>&1; if [ $? -eq 1 ]; then echo "1"; fi)
-if [ "${GIT_DIFF}" == "1" ]; then
-    GIT_TREESTATE="dirty"
-fi
+    # Git information, used to set clusterpedia version
+    GIT_VERSION=$(git describe --tags --dirty)
+    GIT_COMMIT_HASH=$(git rev-parse HEAD)
 
-KUBE_DEPENDENCE_VERSION=$(go list -m k8s.io/kubernetes | cut -d' ' -f2)
+    GIT_TREESTATE="clean"
+    GIT_DIFF=$(git diff --quiet >/dev/null 2>&1; if [ $? -eq 1 ]; then echo "1"; fi)
+    if [ "${GIT_DIFF}" == "1" ]; then
+        GIT_TREESTATE="dirty"
+    fi
 
-LDFLAGS+=" -X github.com/clusterpedia-io/clusterpedia/pkg/version.gitVersion=${GIT_VERSION}"
-LDFLAGS+=" -X github.com/clusterpedia-io/clusterpedia/pkg/version.gitCommit=${GIT_COMMIT_HASH}"
-LDFLAGS+=" -X github.com/clusterpedia-io/clusterpedia/pkg/version.gitTreeState=${GIT_TREESTATE}"
-LDFLAGS+=" -X github.com/clusterpedia-io/clusterpedia/pkg/version.buildDate=${BUILD_DATE}"
+    KUBE_DEPENDENCE_VERSION=$(go list -m k8s.io/kubernetes | cut -d' ' -f2)
 
-# The `client-go/pkg/version` effects the **User-Agent** when using client-go to request.
-# User-Agent="<bin name>/$(GIT_VERSION) ($(GOOS)/$(GOARCH)) kubernetes/$(GIT_COMMIT_HASH)[/<component name>]"
-#   eg. "clustersynchro-manager/0.4.0 (linux/amd64) kubernetes/fbf0f4f/clustersynchro-manager"
-LDFLAGS+=" -X k8s.io/client-go/pkg/version.gitVersion=${GIT_VERSION}"
-LDFLAGS+=" -X k8s.io/client-go/pkg/version.gitMajor=$(echo ${GIT_VERSION#v} | cut -d. -f1)"
-LDFLAGS+=" -X k8s.io/client-go/pkg/version.gitMinor=$(echo ${GIT_VERSION#v} | cut -d. -f2)"
-LDFLAGS+=" -X k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT_HASH}"
-LDFLAGS+=" -X k8s.io/client-go/pkg/version.gitTreeState=${GIT_TREESTATE}"
-LDFLAGS+=" -X k8s.io/client-go/pkg/version.buildDate=${BUILD_DATE}"
+    local ldflags
+    ldflags+=" -X github.com/clusterpedia-io/clusterpedia/pkg/version.gitVersion=${GIT_VERSION}"
+    ldflags+=" -X github.com/clusterpedia-io/clusterpedia/pkg/version.gitCommit=${GIT_COMMIT_HASH}"
+    ldflags+=" -X github.com/clusterpedia-io/clusterpedia/pkg/version.gitTreeState=${GIT_TREESTATE}"
+    ldflags+=" -X github.com/clusterpedia-io/clusterpedia/pkg/version.buildDate=${BUILD_DATE}"
+
+    # The `client-go/pkg/version` effects the **User-Agent** when using client-go to request.
+    # User-Agent="<bin name>/$(GIT_VERSION) ($(GOOS)/$(GOARCH)) kubernetes/$(GIT_COMMIT_HASH)[/<component name>]"
+    #   eg. "clustersynchro-manager/0.4.0 (linux/amd64) kubernetes/fbf0f4f/clustersynchro-manager"
+    ldflags+=" -X k8s.io/client-go/pkg/version.gitVersion=${GIT_VERSION}"
+    ldflags+=" -X k8s.io/client-go/pkg/version.gitMajor=$(echo ${GIT_VERSION#v} | cut -d. -f1)"
+    ldflags+=" -X k8s.io/client-go/pkg/version.gitMinor=$(echo ${GIT_VERSION#v} | cut -d. -f2)"
+    ldflags+=" -X k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT_HASH}"
+    ldflags+=" -X k8s.io/client-go/pkg/version.gitTreeState=${GIT_TREESTATE}"
+    ldflags+=" -X k8s.io/client-go/pkg/version.buildDate=${BUILD_DATE}"
 
 
-# The `component-base/version` effects the version obtained using Kubernetes OpenAPI.
-#   OpenAPI Path: /apis/clusterpedia.io/v1beta1/resources/version
-#   $ kubectl version
+    # The `component-base/version` effects the version obtained using Kubernetes OpenAPI.
+    #   OpenAPI Path: /apis/clusterpedia.io/v1beta1/resources/version
+    #   $ kubectl version
 
-LDFLAGS+=" -X k8s.io/component-base/version.gitVersion=${KUBE_DEPENDENCE_VERSION}"
-LDFLAGS+=" -X k8s.io/component-base/version.gitMajor=$(echo ${KUBE_DEPENDENCE_VERSION#v} | cut -d. -f1)"
-LDFLAGS+=" -X k8s.io/component-base/version.gitMinor=$(echo ${KUBE_DEPENDENCE_VERSION#v} | cut -d. -f2)"
-LDFLAGS+=" -X k8s.io/component-base/version.gitCommit=${GIT_COMMIT_HASH}"
-LDFLAGS+=" -X k8s.io/component-base/version.gitTreeState=${GIT_TREESTATE}"
-LDFLAGS+=" -X k8s.io/component-base/version.buildDate=${BUILD_DATE}"
+    ldflags+=" -X k8s.io/component-base/version.gitVersion=${KUBE_DEPENDENCE_VERSION}"
+    ldflags+=" -X k8s.io/component-base/version.gitMajor=$(echo ${KUBE_DEPENDENCE_VERSION#v} | cut -d. -f1)"
+    ldflags+=" -X k8s.io/component-base/version.gitMinor=$(echo ${KUBE_DEPENDENCE_VERSION#v} | cut -d. -f2)"
+    ldflags+=" -X k8s.io/component-base/version.gitCommit=${GIT_COMMIT_HASH}"
+    ldflags+=" -X k8s.io/component-base/version.gitTreeState=${GIT_TREESTATE}"
+    ldflags+=" -X k8s.io/component-base/version.buildDate=${BUILD_DATE}"
+
+    echo $ldflags
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug
**What this PR does / why we need it**:
When building a repository without any tags, `GIT_VERSION` will cause the build to fail and quit
```bash
make apiserver
hack/builder.sh apiserver
fatal: No names found, cannot describe anything.
make: *** [apiserver] Error 128
```
**We fork clusterpedia/clusterpedia directly and clone the forked repository, then we run into this problem during build**


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
