### PR TITLE
chore: updated .gitignore to ignore the certificates related files during development and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,12 @@
 # OSX trash
 .DS_Store
 
+# Certificate related credential files
+*.pem
+*.crt
+*.cer
+*.key
+*.p12
+
 # apiserver local up cert trash
 apiserver.local.config


### PR DESCRIPTION
## What type of PR is this?

/kind design

## What this PR does / why we need it:

During development and testing with either `apiserver` or `clustersynchro-manager` modules, temporary certificates will be generated and should never be committed, this Pull Request introduces to ignore a set of extensions of certificates related files in `.gitignore`.

## Which issue(s) this PR fixes

None.

## Special notes for your reviewer

## Does this PR introduce a user-facing change?

```release-note
None
```
