### PR TITLE
add OTEL trace for clusterpedia-apiserver

### DIFF
--- a/cmd/apiserver/app/options/options.go
+++ b/cmd/apiserver/app/options/options.go
@@ -39,7 +39,7 @@ type ClusterPediaServerOptions struct {
 	CoreAPI        *genericoptions.CoreAPIOptions
 	FeatureGate    featuregate.FeatureGate
 	Admission      *genericoptions.AdmissionOptions
-	//      Traces         *genericoptions.TracingOptions
+	Traces         *genericoptions.TracingOptions
 
 	Storage *storageoptions.StorageOptions
 }
@@ -66,7 +66,7 @@ func NewServerOptions() *ClusterPediaServerOptions {
 		CoreAPI:        genericoptions.NewCoreAPIOptions(),
 		FeatureGate:    feature.DefaultFeatureGate,
 		Admission:      genericoptions.NewAdmissionOptions(),
-		//      Traces:         genericoptions.NewTracingOptions(),
+		Traces:         genericoptions.NewTracingOptions(),
 
 		Storage: storageoptions.NewStorageOptions(),
 	}
@@ -154,6 +154,9 @@ func (o *ClusterPediaServerOptions) genericOptionsApplyTo(config *genericapiserv
 	if err := o.Admission.ApplyTo(&config.Config, config.SharedInformerFactory, client, dynamicClient, o.FeatureGate); err != nil {
 		return err
 	}
+	if err := o.Traces.ApplyTo(nil, &config.Config); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -176,7 +179,7 @@ func (o *ClusterPediaServerOptions) Flags() cliflag.NamedFlagSets {
 	logsapi.AddFlags(o.Logs, fss.FlagSet("logs"))
 
 	// o.Admission.AddFlags(fss.FlagSet("admission"))
-	// o.Traces.AddFlags(fss.FlagSet("traces"))
+	o.Traces.AddFlags(fss.FlagSet("traces"))
 
 	o.Storage.AddFlags(fss.FlagSet("storage"))
 	return fss

--- a/deploy/clusterpedia_apiserver_deployment.yaml
+++ b/deploy/clusterpedia_apiserver_deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - /usr/local/bin/apiserver
         - --secure-port=443
         - --storage-config=/etc/clusterpedia/storage/internalstorage-config.yaml
+        - --tracing-config-file=/etc/clusterpedia/trace/tracing-config.yaml
         - -v=3
         env:
         - name: DB_PASSWORD
@@ -52,8 +53,27 @@ spec:
         - name: internalstorage-config
           mountPath: /etc/clusterpedia/storage
           readOnly: true
+        - name: tracing-config
+          mountPath: /etc/clusterpedia/trace
+          readOnly: true
       serviceAccountName: clusterpedia-apiserver
       volumes:
       - name: internalstorage-config
         configMap:
           name: clusterpedia-internalstorage
+      - name: tracing-config
+        configMap:
+          name: clusterpedia-tracing-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clusterpedia-tracing-config
+  namespace: clusterpedia-system
+data:
+  tracing-config.yaml: |
+    apiVersion: apiserver.config.k8s.io/v1beta1
+    kind: TracingConfiguration
+    # default
+    # endpoint: localhost:4317
+    samplingRatePerMillion: 1000000

--- a/kustomize/apiserver/clusterpedia_apiserver_deployment.yaml
+++ b/kustomize/apiserver/clusterpedia_apiserver_deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - /usr/local/bin/apiserver
         - --secure-port=443
         - --storage-config=/etc/clusterpedia/storage/internalstorage-config.yaml
+        - --tracing-config-file=/etc/clusterpedia/trace/tracing-config.yaml
         - -v=3
         env:
         - name: DB_PASSWORD
@@ -52,8 +53,27 @@ spec:
         - name: internalstorage-config
           mountPath: /etc/clusterpedia/storage
           readOnly: true
+        - name: tracing-config
+          mountPath: /etc/clusterpedia/trace
+          readOnly: true
       serviceAccountName: clusterpedia-apiserver
       volumes:
       - name: internalstorage-config
         configMap:
           name: clusterpedia-internalstorage
+      - name: tracing-config
+        configMap:
+          name: clusterpedia-tracing-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clusterpedia-tracing-config
+  namespace: clusterpedia-system
+data:
+  tracing-config.yaml: |
+    apiVersion: apiserver.config.k8s.io/v1beta1
+    kind: TracingConfiguration
+    # default
+    # endpoint: localhost:4317
+    samplingRatePerMillion: 1000000

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -124,6 +124,7 @@ func (config completedConfig) New() (*ClusterPediaServer, error) {
 	resourceServerConfig := kubeapiserver.NewDefaultConfig()
 	resourceServerConfig.GenericConfig.ExternalAddress = config.GenericConfig.ExternalAddress
 	resourceServerConfig.GenericConfig.LoopbackClientConfig = config.GenericConfig.LoopbackClientConfig
+	resourceServerConfig.GenericConfig.TracerProvider = config.GenericConfig.TracerProvider
 	resourceServerConfig.ExtraConfig = kubeapiserver.ExtraConfig{
 		InformerFactory:          clusterpediaInformerFactory,
 		StorageFactory:           config.StorageFactory,

--- a/pkg/kubeapiserver/apiserver.go
+++ b/pkg/kubeapiserver/apiserver.go
@@ -11,9 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericfeatures "k8s.io/apiserver/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 	"k8s.io/apiserver/pkg/server/healthz"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/restmapper"
 
 	informers "github.com/clusterpedia-io/clusterpedia/pkg/generated/informers/externalversions"
@@ -144,6 +146,10 @@ func BuildHandlerChain(apiHandler http.Handler, c *genericapiserver.Config) http
 
 	// https://github.com/clusterpedia-io/clusterpedia/issues/54
 	handler = filters.RemoveFieldSelectorFromRequest(handler)
+
+	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
+		handler = genericapifilters.WithTracing(handler, c.TracerProvider)
+	}
 
 	/* used for debugging
 	handler = genericapifilters.WithWarningRecorder(handler)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

new support opentelemetry trace for clusterpedia-apiserver，and enhance observability capabilities

**Which issue(s) this PR fixes**:
Fixes #None

**Special notes for your reviewer**:

The dafault FeatureGate APIServerTracing is enabled, we also need  provide the apiserver with a tracing configuration file with --tracing-config-file=&lt;path-to-config>. 

This is an example config that records spans for 1 in 10000 requests, and uses the default OpenTelemetry endpoint:

```
apiVersion: apiserver.config.k8s.io/v1beta1
kind: TracingConfiguration
# default value
#endpoint: localhost:4317
samplingRatePerMillion: 100
```
Detailed info can be referenced  https://kubernetes.io/docs/concepts/cluster-administration/system-traces/

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
support opentelemetry trace for clusterpedia-apiserver
```
