### PR TITLE
fix: direct `[]byte` write when updating resources

### DIFF
--- a/pkg/storage/internalstorage/resource_storage.go
+++ b/pkg/storage/internalstorage/resource_storage.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strconv"
 
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -107,7 +108,7 @@ func (s *ResourceStorage) Update(ctx context.Context, cluster string, obj runtim
 		"owner_uid":        ownerUID,
 		"uid":              metaobj.GetUID(),
 		"resource_version": metaobj.GetResourceVersion(),
-		"object":           buffer.Bytes(),
+		"object":           datatypes.JSON(buffer.Bytes()),
 	}
 	if deletedAt := metaobj.GetDeletionTimestamp(); deletedAt != nil {
 		updatedResource["deleted_at"] = sql.NullTime{Time: deletedAt.Time, Valid: true}

--- a/pkg/storage/internalstorage/storage_test.go
+++ b/pkg/storage/internalstorage/storage_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	gmysql "gorm.io/driver/mysql"
 	gpostgres "gorm.io/driver/postgres"
+	gsqlite "gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
@@ -32,6 +33,25 @@ func newMockedPostgresDB() (*gorm.DB, sqlmock.Sqlmock, error) {
 	}
 
 	return gormDB, mock, nil
+}
+
+func newSQLiteDB() (*gorm.DB, func(), error) {
+	db, err := gorm.Open(gsqlite.Open("test.db"))
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	err = db.AutoMigrate(&Resource{})
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	return db, func() {
+		err := os.Remove("test.db")
+		if err != nil {
+			panic(err)
+		}
+	}, nil
 }
 
 func newMockedMySQLDB(version string) (*gorm.DB, sqlmock.Sqlmock, error) {

--- a/pkg/storage/internalstorage/util_test.go
+++ b/pkg/storage/internalstorage/util_test.go
@@ -121,6 +121,7 @@ func assertPostgresDatabaseExecutedSQL[P any](
 	db, mock, err := newMockedPostgresDB()
 	require.NoError(t, err)
 	require.NotNil(t, db)
+	require.NotNil(t, mock)
 
 	assertDatabaseExecutedSQL(t, db, mock, options, applyFn, expectedQuery, args, expectedError)
 }
@@ -137,6 +138,7 @@ func assertMySQLDatabaseExecutedSQL[P any](
 	db, mock, err := newMockedMySQLDB(version)
 	require.NoError(t, err)
 	require.NotNil(t, db)
+	require.NotNil(t, mock)
 
 	assertDatabaseExecutedSQL(t, db, mock, options, applyFn, expectedQuery, args, expectedError)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently it writes without the help of `datatypes.JSON` when updating field `object`:

```go
	updatedResource := map[string]interface{}{
		"owner_uid":        ownerUID,
		"uid":              metaobj.GetUID(),
		"resource_version": metaobj.GetResourceVersion(),
		"object":           buffer.Bytes(),
	}
```

which will cause the `object` field to be hex (binary) format when querying with database tools as following:

<img width="2279" alt="image" src="https://github.com/clusterpedia-io/clusterpedia/assets/11081491/bd983b85-a6a1-45d9-8d8e-86de122227ca">

1. wrapped `datatypes.JSON` when updating `object`

## Which issue(s) this PR fixes

None.

## Special notes for your reviewer

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
