### PR TITLE
chore: added more certificate and test use sqlite db related ignore for `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,29 @@
 .DS_Store
 
 # Certificate related credential files
+# Encoding of certificates and private keys
 *.pem
+*.der
+# Certificate related
 *.crt
 *.cer
+*.ca-bundle
+# Certificate signing request
+*.csr
+# Certificate revoking list
+*.crl
+# Private key related
 *.key
 *.p12
+*.pfx
+# PKCS#7 related
+*.p7b
+*.p7r
+*.p7r
+*.spc
 
 # apiserver local up cert trash
 apiserver.local.config
+
+# SQLite DB Files
+*.db


### PR DESCRIPTION
## What type of PR is this

/kind cleanup

## What this PR does / why we need it

Subset changes for #602. It wasn't enough for just ignoring the existing extensions, and #607 introduces `test.db` files in unit tests, this Pull Request suggest to cover more ignorance of certificate related extensions and `test.db`.

## Which issue(s) this PR fixes

None.

## Special notes for your reviewer

## Does this PR introduce a user-facing change
```release-note
NONE
```
