### PR TITLE
add featureGate IgnoreLeaseSync to stop sync leases.coordination.k8s.io

### DIFF
--- a/pkg/synchromanager/clustersynchro/resource_negotiator.go
+++ b/pkg/synchromanager/clustersynchro/resource_negotiator.go
@@ -87,6 +87,14 @@ func (negotiator *ResourceNegotiator) NegotiateSyncResources(syncResources []clu
 	for _, groupResources := range syncResources {
 		for _, resource := range groupResources.Resources {
 			syncGR := schema.GroupResource{Group: groupResources.Group, Resource: resource}
+
+			if clusterpediafeature.FeatureGate.Enabled(features.IgnoreLeaseSync) {
+				// skip leases.coordination.k8s.io
+				if syncGR.String() == "leases.coordination.k8s.io" {
+					continue
+				}
+			}
+
 			apiResource, supportedVersions := negotiator.dynamicDiscovery.GetAPIResourceAndVersions(syncGR)
 			if apiResource == nil || len(supportedVersions) == 0 {
 				continue

--- a/pkg/synchromanager/features/features.go
+++ b/pkg/synchromanager/features/features.go
@@ -61,6 +61,13 @@ const (
 	// owner: @iceber
 	// alpha: v0.8.0
 	StreamHandlePaginatedListForResourceSync featuregate.Feature = "StreamHandlePaginatedListForResourceSync"
+
+	// IgnoreLeaseSync is a feature gate for the ClusterSynchro to skip syncing leases.coordination.k8s.io,
+	// if you enable this feature, these resources will not be synced no matter what `syncResources` are defined.
+	//
+	// owner: @27149chen
+	// alpha: v0.8.0
+	IgnoreLeaseSync featuregate.Feature = "IgnoreLeaseSync"
 )
 
 func init() {
@@ -78,4 +85,5 @@ var defaultClusterSynchroManagerFeatureGates = map[featuregate.Feature]featurega
 
 	ForcePaginatedListForResourceSync:        {Default: false, PreRelease: featuregate.Alpha},
 	StreamHandlePaginatedListForResourceSync: {Default: false, PreRelease: featuregate.Alpha},
+	IgnoreLeaseSync:                          {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind feature

**What this PR does / why we need it**:

This pr adds a featureGate `IgnoreLeaseSync` to stop synchronizing internal resources that the majority of users do not care about. Currently only `leases.coordination.k8s.io` is added since it updates too frequently.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
Add a featureGate `SkipSyncLeases` to stop synchronizing `leases.coordination.k8s.io`
```
