### PR TITLE
add ConvertDeletedObject method for ResourceStorage

### DIFF
--- a/pkg/storage/internalstorage/resource_storage.go
+++ b/pkg/storage/internalstorage/resource_storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	genericstorage "k8s.io/apiserver/pkg/storage"
+	"k8s.io/client-go/tools/cache"
 
 	internal "github.com/clusterpedia-io/api/clusterpedia"
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
@@ -123,6 +124,22 @@ func (s *ResourceStorage) Update(ctx context.Context, cluster string, obj runtim
 		"name":      metaobj.GetName(),
 	}).Updates(updatedResource)
 	return InterpretResourceDBError(cluster, metaobj.GetName(), result.Error)
+}
+
+func (c *ResourceStorage) ConvertDeletedObject(obj interface{}) (runtime.Object, error) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Since it is not necessary to save the complete deleted object to the queue,
+	// we convert the object to `PartialObjectMetadata`
+	return &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}, nil
 }
 
 func (s *ResourceStorage) deleteObject(cluster, namespace, name string) *gorm.DB {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -36,6 +36,8 @@ type ResourceStorage interface {
 
 	Create(ctx context.Context, cluster string, obj runtime.Object) error
 	Update(ctx context.Context, cluster string, obj runtime.Object) error
+
+	ConvertDeletedObject(obj interface{}) (runtime.Object, error)
 	Delete(ctx context.Context, cluster string, obj runtime.Object) error
 }
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
The storage layer can convert the type of the deleted object so that the storage layer can cache the necessary information from the object in a queue
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
