### PR TITLE
set the default value of the feature gate APIServerTracing to false

### DIFF
--- a/kustomize/apiserver/clusterpedia_apiserver_deployment.yaml
+++ b/kustomize/apiserver/clusterpedia_apiserver_deployment.yaml
@@ -42,6 +42,7 @@ spec:
         - --secure-port=443
         - --storage-config=/etc/clusterpedia/storage/internalstorage-config.yaml
         - --tracing-config-file=/etc/clusterpedia/trace/tracing-config.yaml
+        - --feature-gates=APIServerTracing=true
         - -v=3
         env:
         - name: DB_PASSWORD


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
There's no point in turning on trace when the user hasn't set up a trace config, and although the trace middleware will append some information to the context in the case of noop trace, clusterpedia doesn't currently use them.

Now set the default value of APIServerTracing to false and enable it when the user wants to use it.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
