### PR TITLE
update the created_at field when updating resource

### DIFF
--- a/pkg/storage/internalstorage/resource_storage.go
+++ b/pkg/storage/internalstorage/resource_storage.go
@@ -110,6 +110,7 @@ func (s *ResourceStorage) Update(ctx context.Context, cluster string, obj runtim
 		"uid":              metaobj.GetUID(),
 		"resource_version": metaobj.GetResourceVersion(),
 		"object":           datatypes.JSON(buffer.Bytes()),
+		"created_at":       metaobj.GetCreationTimestamp().Time,
 	}
 	if deletedAt := metaobj.GetDeletionTimestamp(); deletedAt != nil {
 		updatedResource["deleted_at"] = sql.NullTime{Time: deletedAt.Time, Valid: true}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
When `clustersynchro-manager` updating resource, the created_at field would not be updated, which may lead to the created_at of the resource inconsistent with the creationTimestamp of the object.

![image](https://github.com/clusterpedia-io/clusterpedia/assets/13435258/e1090d71-c5c3-4c9a-aad2-1d4c2dbe0d21)


**Which issue(s) this PR fixes**:
Fixes #626 

**Special notes for your reviewer**:

test results:


<img width="732" alt="image" src="https://github.com/clusterpedia-io/clusterpedia/assets/13435258/429713c6-89d0-47dc-bb1f-20d9c82adbf0">

the created_at for `elastic-operator-0` and `amamba-argocd-application-controller-0` has been updated:
<img width="731" alt="image" src="https://github.com/clusterpedia-io/clusterpedia/assets/13435258/7ff50a0a-f216-40df-ac7a-8156e70f6fb4">


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
