### PR TITLE
Revert "set the default value of the feature gate APIServerTracing to false" #627 

### DIFF
--- a/cmd/apiserver/app/apiserver.go
+++ b/cmd/apiserver/app/apiserver.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -68,25 +67,15 @@ func NewClusterPediaServerCommand(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
-var wrapedDefaultFeatureGate = map[featuregate.Feature]bool{
-	// https://github.com/clusterpedia-io/clusterpedia/issues/196
-	genericfeatures.RemainingItemCount: false,
-
-	genericfeatures.APIServerTracing: false,
-}
-
 func init() {
 	runtime.Must(logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
 
+	// The feature gate `RemainingItemCount` should default to false
+	// https://github.com/clusterpedia-io/clusterpedia/issues/196
 	gates := utilfeature.DefaultMutableFeatureGate.GetAll()
-	for feature, value := range wrapedDefaultFeatureGate {
-		gate, ok := gates[feature]
-		if !ok {
-			panic(fmt.Sprintf("FeatureGate[%s] is not existed in the default feature gates", feature))
-		}
-		gate.Default = value
-		gates[feature] = gate
-	}
+	gate := gates[genericfeatures.RemainingItemCount]
+	gate.Default = false
+	gates[genericfeatures.RemainingItemCount] = gate
 
 	utilfeature.DefaultMutableFeatureGate = featuregate.NewFeatureGate()
 	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(gates))

--- a/kustomize/apiserver/clusterpedia_apiserver_deployment.yaml
+++ b/kustomize/apiserver/clusterpedia_apiserver_deployment.yaml
@@ -42,7 +42,6 @@ spec:
         - --secure-port=443
         - --storage-config=/etc/clusterpedia/storage/internalstorage-config.yaml
         - --tracing-config-file=/etc/clusterpedia/trace/tracing-config.yaml
-        - --feature-gates=APIServerTracing=true
         - -v=3
         env:
         - name: DB_PASSWORD


### PR DESCRIPTION
revert "set the default value of the feature gate APIServerTracing to false"

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
There is no guarantee that future apiserver libraries will make any judgements based on the information in this ctx, so the default state of this feature gating is maintained

The user can choose to set it to false

related pr: https://github.com/clusterpedia-io/clusterpedia/pull/630
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
