### PR TITLE
fix otel trace handler WithTracing, use another func

### DIFF
--- a/pkg/kubeapiserver/apiserver.go
+++ b/pkg/kubeapiserver/apiserver.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/restmapper"
+	"k8s.io/component-base/tracing"
 
 	informers "github.com/clusterpedia-io/clusterpedia/pkg/generated/informers/externalversions"
 	"github.com/clusterpedia-io/clusterpedia/pkg/kubeapiserver/discovery"
@@ -148,7 +149,7 @@ func BuildHandlerChain(apiHandler http.Handler, c *genericapiserver.Config) http
 	handler = filters.RemoveFieldSelectorFromRequest(handler)
 
 	if utilfeature.DefaultFeatureGate.Enabled(genericfeatures.APIServerTracing) {
-		handler = genericapifilters.WithTracing(handler, c.TracerProvider)
+		handler = tracing.WithTracing(handler, c.TracerProvider, "ClusterpediaAPI")
 	}
 
 	/* used for debugging


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

Fixed OTEL trace interruption when other services requested clusterpedia apiserver. And this is caused by `otelhttp.WithPublicEndpoint()`. As shown here https://github.com/kubernetes/kubernetes/blob/09a5049ca785024edd4955eb82e855d9b5657491/staging/src/k8s.io/apiserver/pkg/endpoints/filters/traces.go#L33C20-L33C20

And I think it's a bug of kubernetes, so I  replaced it with `WithTracing` in pkg k8s.io/component-base/tracing.

**Which issue(s) this PR fixes**:
Fixes #None

**Special notes for your reviewer**:

The two `WithTracing` is almost same and we can customize the span name by the new one. So it's more flexible.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix otel trace handler WithTracing
```
