### PR TITLE
Change the storage plugin name to sample-storage

### DIFF
--- a/hack/builder.sh
+++ b/hack/builder.sh
@@ -18,7 +18,7 @@ ENV:
             eg. CLUSTERPEDIA_REPO=/clusterpedia
 
     PLUGIN_REPO: plugin repo path, required if the pwd is not the plugin repository.
-            eg. CLUSTERPEDIA_REPO=/plugins/sample-storage-layer
+            eg. CLUSTERPEDIA_REPO=/plugins/sample-storage
 
     OUTPUT_DIR: default is the root of the repository or pwd,
                 the component binary will be output in \$OUTPUT_DIR/bin, the plugins will be output in \$OUTPUT_DIR/plugins.


### PR DESCRIPTION
**What type of PR is this?**
Change the storage plugin name to sample-storage.

Related PR: https://github.com/clusterpedia-io/sample-storage/pull/6

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes # https://github.com/clusterpedia-io/sample-storage-layer/issues/2

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
