### PR TITLE
apiserver: unlock the RemainingItemCount feature gate

### DIFF
--- a/cmd/apiserver/app/apiserver.go
+++ b/cmd/apiserver/app/apiserver.go
@@ -75,6 +75,7 @@ func init() {
 	gates := utilfeature.DefaultMutableFeatureGate.GetAll()
 	gate := gates[genericfeatures.RemainingItemCount]
 	gate.Default = false
+	gate.LockToDefault = false
 	gates[genericfeatures.RemainingItemCount] = gate
 
 	utilfeature.DefaultMutableFeatureGate = featuregate.NewFeatureGate()


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

/kind bug

**What this PR does / why we need it**:
Although RemainingItemCount is locked in the apiserver's native feature gate, it still needs to be supported in Clusterpedia for users to modify it.
**Which issue(s) this PR fixes**:
Fixes https://github.com/clusterpedia-io/clusterpedia/pull/668#issuecomment-2167237307
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
