### PR TITLE
bump golang from 1.22.4 to 1.22.6

### DIFF
--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,15 +1,6 @@
-FROM golang:1.22.4
-
-# FROM golang:1.19.2-alpine
-# RUN apk add --no-cache build-base git bash
-
+FROM golang:1.22.6
 RUN apt-get update && apt-get install -y gcc-aarch64-linux-gnu gcc-x86-64-linux-gnu
 
 COPY . /clusterpedia
-
-# RUN rm -rf /clusterpedia/.git
-# RUN rm -rf /clusterpedia/test
-
 ENV CLUSTERPEDIA_REPO="/clusterpedia"
-
 RUN cp /clusterpedia/hack/builder.sh /


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
There is no need to update the minor version.

**Which issue(s) this PR fixes**:
related pr:  https://github.com/clusterpedia-io/clusterpedia/pull/687

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
