### PR TITLE
metrics: use legacyregister instead of new registry

### DIFF
--- a/pkg/kube_state_metrics/server.go
+++ b/pkg/kube_state_metrics/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/exporter-toolkit/web"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 
 	"github.com/clusterpedia-io/clusterpedia/pkg/metrics"
@@ -26,7 +27,7 @@ type ServerConfig struct {
 }
 
 func RunServer(config ServerConfig, getter ClusterMetricsWriterListGetter) {
-	durationVec := promauto.With(metrics.DefaultRegistry()).NewHistogramVec(
+	durationVec := promauto.With(legacyregistry.Registerer()).NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:        "http_request_duration_seconds",
 			Help:        "A histogram of requests for clusterpedia's kube-state-metrics metrics handler.",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,16 +1,12 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	versionCollector "github.com/prometheus/client_golang/prometheus/collectors/version"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
-var registry = prometheus.NewRegistry()
-
-func DefaultRegistry() prometheus.Registerer {
-	return registry
-}
-
 func init() {
-	registry.MustRegister(versionCollector.NewCollector("clusterpedia_kube_state_metrics"))
+	legacyregistry.RawMustRegister(
+		versionCollector.NewCollector("clusterpedia_kube_state_metrics"),
+	)
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
Use compose-base/metrics instead of prometheus.Registry directly

This has several benefits:
1. use the same Metrics as the clusterpedia apierver, and the metrics can be aggregated for display in the binding-apiserver command
2. Golang Metrics and Process Metrics are now registered.
3. more advanced functionality for future use of compose-base/metrics

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
