### PR TITLE
test: check the clusterpedia apiserver before test cases

### DIFF
--- a/test/environments/multiple.env.sh
+++ b/test/environments/multiple.env.sh
@@ -52,4 +52,9 @@ done
 
 "${ROOT}/hack/gen-clusterconfigs.sh"
 
+if ! check_clusterpedia_apiserver; then
+    echo "clusterpedia apiserver is not ready"
+    exit 1
+fi
+
 "${cases}"

--- a/test/environments/single.env.sh
+++ b/test/environments/single.env.sh
@@ -31,4 +31,9 @@ create_data_plane ${data_plane_name} ${version} || {
 
 "${ROOT}/hack/gen-clusterconfigs.sh"
 
+if ! check_clusterpedia_apiserver; then
+    echo "clusterpedia apiserver is not ready"
+    exit 1
+fi
+
 "${cases}"

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -162,3 +162,15 @@ function delete_data_plane() {
     kwokctl export logs --name "${name}" "${ROOT}/test/logs/kwok/${name}"
     kwokctl delete cluster --name "${name}"
 }
+
+# check if the apiserver in the control plane is ready
+function check_clusterpedia_apiserver() {
+    for i in {1..3}
+    do
+        if kubectl get --raw="/apis/clusterpedia.io/v1beta1/">/dev/null; then # only print error messages of the kubectl
+            return 0
+        fi
+        sleep 10
+    done
+    return 1
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind failing-test

**What this PR does / why we need it**:
Both apiserver and clustersynchro manager trigger attempts to **create database tables** when they are started at the same time, and we have found from https://github.com/clusterpedia-io/clusterpedia/pull/702 that there are concurrency issues due to gorm design issues.

https://github.com/clusterpedia-io/clusterpedia/actions/runs/11732967909/job/33175301980?pr=702#step:4:818

https://github.com/go-gorm/gorm/issues/6618

In production, it will automatically retry, but in testing, you need to add a check to avoid subsequent test failures.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
