### PR TITLE
memorystorage: fix deleting cluster info when cleaning a resource

### DIFF
--- a/pkg/storage/memorystorage/memory_storage.go
+++ b/pkg/storage/memorystorage/memory_storage.go
@@ -94,7 +94,6 @@ func (s *StorageFactory) CleanClusterResource(ctx context.Context, cluster strin
 	if rs, ok := storages.resourceStorages[gvr]; ok {
 		rs.CrvSynchro.RemoveCluster(cluster)
 		rs.watchCache.CleanCluster(cluster)
-		delete(s.clusters, cluster)
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind bug

**What this PR does / why we need it**:
Cluster information is deleted when cleaning up a resource, and new synchronized resources cannot be added in the future.

This means that after a cluster deletes a synchronized resource, it cannot synchronize a new resource type

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
