### PR TITLE
apiserver: add enable subresource options

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -64,6 +64,7 @@ type Config struct {
 	GenericConfig *genericapiserver.RecommendedConfig
 
 	StorageFactory storage.StorageFactory
+	ExtraConfig    *kubeapiserver.ExtraConfig
 }
 
 type ClusterPediaServer struct {
@@ -75,6 +76,7 @@ type completedConfig struct {
 
 	ClientConfig   *clientrest.Config
 	StorageFactory storage.StorageFactory
+	ExtraConfig    *kubeapiserver.ExtraConfig
 }
 
 // CompletedConfig embeds a private pointer that cannot be instantiated outside of this package.
@@ -90,6 +92,7 @@ func (cfg *Config) Complete() CompletedConfig {
 		cfg.GenericConfig.Complete(),
 		cfg.GenericConfig.ClientConfig,
 		cfg.StorageFactory,
+		cfg.ExtraConfig,
 	}
 	return CompletedConfig{&c}
 }
@@ -121,11 +124,10 @@ func (config completedConfig) New() (*ClusterPediaServer, error) {
 	resourceServerConfig.GenericConfig.ExternalAddress = config.GenericConfig.ExternalAddress
 	resourceServerConfig.GenericConfig.LoopbackClientConfig = config.GenericConfig.LoopbackClientConfig
 	resourceServerConfig.GenericConfig.TracerProvider = config.GenericConfig.TracerProvider
-	resourceServerConfig.ExtraConfig = kubeapiserver.ExtraConfig{
-		InformerFactory:          clusterpediaInformerFactory,
-		StorageFactory:           config.StorageFactory,
-		InitialAPIGroupResources: initialAPIGroupResources,
-	}
+	resourceServerConfig.InformerFactory = clusterpediaInformerFactory
+	resourceServerConfig.StorageFactory = config.StorageFactory
+	resourceServerConfig.InitialAPIGroupResources = initialAPIGroupResources
+	resourceServerConfig.ExtraConfig = config.ExtraConfig
 	kubeResourceAPIServer, methods, err := resourceServerConfig.Complete().New(genericapiserver.NewEmptyDelegate())
 	if err != nil {
 		return nil, err

--- a/pkg/kubeapiserver/options.go
+++ b/pkg/kubeapiserver/options.go
@@ -1,0 +1,79 @@
+package kubeapiserver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type Options struct {
+	AllowedProxySubresources []string
+}
+
+func NewOptions() *Options {
+	return &Options{}
+}
+
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	var resources []string
+	for r, srs := range supportedProxyCoreSubresources {
+		for _, sr := range srs {
+			resources = append(resources, r+"/"+sr)
+		}
+	}
+
+	// To explicitly specify subresources, enabling all subresources of a parent resource
+	// using a pattern like `<resource>/*` is currently not supported.
+	//
+	// If you have a better solution, please submit an issue!
+	fs.StringSliceVar(&o.AllowedProxySubresources, "allowed-proxy-subresources", o.AllowedProxySubresources, ""+
+		"List of subresources that support proxying requests to the specified cluster, formatted as '[resource/subresource],[subresource],...'. "+
+		fmt.Sprintf("Supported proxy subresources include %q", strings.Join(resources, ",")),
+	)
+}
+
+var supportedProxyCoreSubresources = map[string][]string{
+	"pods":     {"proxy", "log", "exec", "attach", "portfowrd"},
+	"nodes":    {"proxy"},
+	"services": {"proxy"},
+}
+
+func (o *Options) Config() (*ExtraConfig, error) {
+	subresources := make(map[schema.GroupResource]sets.Set[string])
+
+	for _, subresource := range o.AllowedProxySubresources {
+		var resource string
+		switch slice := strings.Split(strings.TrimSpace(subresource), "/"); len(slice) {
+		case 1:
+			subresource = slice[0]
+		case 2:
+			resource, subresource = slice[0], slice[1]
+		default:
+			return nil, fmt.Errorf("--allowed-proxy-subresources: invalid format %q", subresource)
+		}
+
+		var matched bool
+		for r, srs := range supportedProxyCoreSubresources {
+			for _, sr := range srs {
+				if (resource == "" || resource == r) && subresource == sr {
+					gr := schema.GroupResource{Group: "", Resource: r}
+					set := subresources[gr]
+					if set == nil {
+						set = sets.New[string]()
+						subresources[gr] = set
+					}
+					set.Insert(sr)
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
+			return nil, fmt.Errorf("--allowed-proxy-subresources: unsupported subresources or invalid format %q", subresource)
+		}
+	}
+	return &ExtraConfig{AllowedProxySubresources: subresources}, nil
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
Enable support for the specified subresource via `--allowed-proxy-subresources` flags. No subresources are turned on by default

With --help you can see all the subresources that are supported to be turned on.
```bash
$ ./bin/apiserver --help
...

Resource server flags:

      --allowed-proxy-subresources strings
                List of subresources that support proxying requests to the specified cluster, formatted as '[resource/subresource],[subresource],...'. Supported
                proxy subresources include "pods/proxy,pods/log,pods/exec,pods/attach,pods/portfowrd,nodes/proxy,services/proxy"

...
```

example:
```bash
$ # Enable the proxy subresources for all resources and the exec subresources of the pods.
$ ./bin/apiserver --allowed-proxy-subresources "pods/exec,proxy"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
