### PR TITLE
apiserver: set proxy auth info via request header

### DIFF
--- a/pkg/kubeapiserver/clusterresource_controller.go
+++ b/pkg/kubeapiserver/clusterresource_controller.go
@@ -1,16 +1,11 @@
 package kubeapiserver
 
 import (
-	"context"
-	"errors"
-	"net/http"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
 	clusterv1alpha2 "github.com/clusterpedia-io/api/cluster/v1alpha2"
@@ -105,66 +100,6 @@ func (c *ClusterResourceController) removeCluster(name string) {
 
 	c.discoveryManager.RemoveCluster(name)
 	delete(c.clusterresources, name)
-}
-
-func (c *ClusterResourceController) resolveClusterRestConfig(name string) (*rest.Config, error) {
-	cluster, err := c.clusterLister.Get(name)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(cluster.Spec.Kubeconfig) != 0 {
-		clientconfig, err := clientcmd.NewClientConfigFromBytes(cluster.Spec.Kubeconfig)
-		if err != nil {
-			return nil, err
-		}
-		return clientconfig.ClientConfig()
-	}
-
-	if cluster.Spec.APIServer == "" {
-		return nil, errors.New("Cluster APIServer Endpoint is required")
-	}
-
-	if len(cluster.Spec.TokenData) == 0 &&
-		(len(cluster.Spec.CertData) == 0 || len(cluster.Spec.KeyData) == 0) {
-		return nil, errors.New("Cluster APIServer's Token or Cert is required")
-	}
-
-	config := &rest.Config{
-		Host: cluster.Spec.APIServer,
-	}
-
-	if len(cluster.Spec.CAData) != 0 {
-		config.TLSClientConfig.CAData = cluster.Spec.CAData
-	} else {
-		config.TLSClientConfig.Insecure = true
-	}
-
-	if len(cluster.Spec.CertData) != 0 && len(cluster.Spec.KeyData) != 0 {
-		config.TLSClientConfig.CertData = cluster.Spec.CertData
-		config.TLSClientConfig.KeyData = cluster.Spec.KeyData
-	}
-
-	if len(cluster.Spec.TokenData) != 0 {
-		config.BearerToken = string(cluster.Spec.TokenData)
-	}
-	return config, nil
-}
-
-func (c *ClusterResourceController) GetClusterDefaultConnection(ctx context.Context, name string) (string, http.RoundTripper, error) {
-	config, err := c.resolveClusterRestConfig(name)
-	if err != nil {
-		return "", nil, err
-	}
-	transport, err := rest.TransportFor(config)
-	if err != nil {
-		return "", nil, err
-	}
-	return config.Host, transport, nil
-}
-
-func (c *ClusterResourceController) GetClusterConnectionWithTLSConfig(ctx context.Context, name string) (string, http.RoundTripper, error) {
-	return "", nil, errors.New("CetClusterConnectionWithTLSConfig not implemented")
 }
 
 type resourceInfo struct {

--- a/pkg/kubeapiserver/resourcerest/proxy/proxy_connector.go
+++ b/pkg/kubeapiserver/resourcerest/proxy/proxy_connector.go
@@ -1,0 +1,122 @@
+package proxy
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"k8s.io/client-go/rest"
+
+	clusterlister "github.com/clusterpedia-io/clusterpedia/pkg/generated/listers/cluster/v1alpha2"
+	"github.com/clusterpedia-io/clusterpedia/pkg/utils"
+)
+
+const DefaultProxyRequestHeaderPrefix = "X-Clusterpedia-Proxy-"
+
+type Connector struct {
+	allowConfigReuse    bool
+	extraHeaderPrefixes []string
+	clusterLister       clusterlister.PediaClusterLister
+}
+
+func NewProxyConnector(clusterLister clusterlister.PediaClusterLister, allowPediaClusterConfigReuse bool, extraHeaderPrefixes []string) ClusterConnectionGetter {
+	if len(extraHeaderPrefixes) == 0 {
+		extraHeaderPrefixes = []string{DefaultProxyRequestHeaderPrefix}
+	}
+	return &Connector{
+		allowConfigReuse:    allowPediaClusterConfigReuse,
+		extraHeaderPrefixes: extraHeaderPrefixes,
+		clusterLister:       clusterLister,
+	}
+}
+
+func (c *Connector) GetClusterConnection(ctx context.Context, name string, req *http.Request) (string, http.RoundTripper, error) {
+	cluster, err := c.clusterLister.Get(name)
+	if err != nil {
+		return "", nil, err
+	}
+	config := &rest.Config{}
+	if cluster.Status.APIServer != "" {
+		config.Host = cluster.Status.APIServer
+	} else if cluster.Spec.APIServer != "" {
+		config.Host = cluster.Spec.APIServer
+	} else {
+		return "", nil, errors.New(".Spec.APIServer and .Status.APIServer are empty")
+	}
+	config.TLSClientConfig.Insecure = true
+
+	var authInHeader bool
+	extra := map[string][]string{}
+
+	headers := req.Header.Clone()
+	for _, prefix := range c.extraHeaderPrefixes {
+		for headerName, vv := range headers {
+			if !(len(headerName) >= len(prefix) && strings.EqualFold(headerName[:len(prefix)], prefix)) {
+				continue
+			}
+
+			extraKey := unescapeExtraKey(strings.ToLower(headerName[len(prefix):]))
+			extra[extraKey] = append(extra[extraKey], vv...)
+			req.Header.Del(headerName)
+		}
+	}
+
+	for key, vals := range extra {
+		switch key {
+		case "ca":
+			authInHeader = true
+			if len(vals) > 0 {
+				config.TLSClientConfig.CAData, err = base64.StdEncoding.DecodeString(vals[0])
+				if err != nil {
+					return "", nil, err
+				}
+				config.TLSClientConfig.Insecure = false
+			}
+		case "token":
+			authInHeader = true
+			if len(vals) > 0 {
+				config.BearerToken = vals[0]
+			}
+		case "client-cert":
+			authInHeader = true
+			if len(vals) > 0 {
+				config.TLSClientConfig.CertData, err = base64.StdEncoding.DecodeString(vals[0])
+				if err != nil {
+					return "", nil, err
+				}
+			}
+		case "client-key":
+			authInHeader = true
+			if len(vals) > 0 {
+				config.TLSClientConfig.KeyData, err = base64.StdEncoding.DecodeString(vals[0])
+				if err != nil {
+					return "", nil, err
+				}
+			}
+		}
+	}
+
+	if !authInHeader && c.allowConfigReuse {
+		config, err = utils.BuildClusterRestConfig(cluster)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	transport, err := rest.TransportFor(config)
+	if err != nil {
+		return "", nil, err
+	}
+	return config.Host, transport, nil
+}
+
+func unescapeExtraKey(encodedKey string) string {
+	key, err := url.PathUnescape(encodedKey) // Decode %-encoded bytes.
+	if err != nil {
+		return encodedKey // Always record extra strings, even if malformed/unencoded.
+	}
+	return key
+}

--- a/pkg/utils/rest.go
+++ b/pkg/utils/rest.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"errors"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	clusterv1alpha2 "github.com/clusterpedia-io/api/cluster/v1alpha2"
+)
+
+func BuildClusterRestConfig(cluster *clusterv1alpha2.PediaCluster) (*rest.Config, error) {
+	if len(cluster.Spec.Kubeconfig) != 0 {
+		clientconfig, err := clientcmd.NewClientConfigFromBytes(cluster.Spec.Kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+		return clientconfig.ClientConfig()
+	}
+
+	if cluster.Spec.APIServer == "" {
+		return nil, errors.New("Cluster APIServer Endpoint is required")
+	}
+
+	if len(cluster.Spec.TokenData) == 0 &&
+		(len(cluster.Spec.CertData) == 0 || len(cluster.Spec.KeyData) == 0) {
+		return nil, errors.New("Cluster APIServer's Token or Cert is required")
+	}
+
+	config := &rest.Config{
+		Host: cluster.Spec.APIServer,
+	}
+
+	if len(cluster.Spec.CAData) != 0 {
+		config.TLSClientConfig.CAData = cluster.Spec.CAData
+	} else {
+		config.TLSClientConfig.Insecure = true
+	}
+
+	if len(cluster.Spec.CertData) != 0 && len(cluster.Spec.KeyData) != 0 {
+		config.TLSClientConfig.CertData = cluster.Spec.CertData
+		config.TLSClientConfig.KeyData = cluster.Spec.KeyData
+	}
+
+	if len(cluster.Spec.TokenData) != 0 {
+		config.BearerToken = string(cluster.Spec.TokenData)
+	}
+	return config, nil
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature
**What this PR does / why we need it**:
Users can set authentication information for proxy requests using the X-Clusterpedia-Proxy- prefix in the request headers, supporting: 
1. X-Clusterpedia-Proxy-CA
2. X-Clusterpedia-Proxy-Token
3. X-Clusterpedia-Proxy-Client-Cert
4. X-Clusterpedia-Proxy-Client-Key

To make the feature more flexible, administrators can allow proxy requests to reuse the PediaCluster configuration by using the `--allow-pediacluster-config-for-proxy-request` flag. However, the permissions of this cluster configuration may not satisfy the proxy requests, and if the permissions are too high, it could lead to unauthorized operations. Additionally, reusing the PediaCluster configuration may also raise auditing issues.
```bash
$ ./bin/apiserver --help
...
Resource server flags:

      --allow-pediacluster-config-for-proxy-request
                Allow proxy requests to use the cluster configuration from PediaCluster when authentication information cannot be obtained from the header.
...
```

**NOTE: However, for kubectl users, passing custom headers is difficult. In the future, we will add a kubectl plugin, but for now, you may need to enable b and ensure that the configuration within PediaCluster has sufficient permissions.**


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
