### PR TITLE
support referencing cluster authentication info from secrets

### DIFF
--- a/cmd/clustersynchro-manager/app/config/config.go
+++ b/cmd/clustersynchro-manager/app/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	componentbaseconfig "k8s.io/component-base/config"
@@ -14,6 +15,8 @@ import (
 
 type Config struct {
 	Kubeconfig    *restclient.Config
+	Namespace     string
+	Client        kubernetes.Interface
 	CRDClient     *crdclientset.Clientset
 	EventRecorder record.EventRecorder
 

--- a/cmd/clustersynchro-manager/app/synchro.go
+++ b/cmd/clustersynchro-manager/app/synchro.go
@@ -92,7 +92,7 @@ func NewClusterSynchroManagerCommand(ctx context.Context) *cobra.Command {
 }
 
 func Run(ctx context.Context, c *config.Config) error {
-	synchromanager := synchromanager.NewManager(c.CRDClient, c.StorageFactory, c.ClusterSyncConfig, c.ShardingName)
+	synchromanager := synchromanager.NewManager(c.Client, c.CRDClient, c.StorageFactory, c.ClusterSyncConfig, c.ShardingName, c.Namespace)
 
 	go func() {
 		metricsserver.Run(c.MetricsServerConfig)

--- a/kustomize/crds/cluster.clusterpedia.io_pediaclusters.yaml
+++ b/kustomize/crds/cluster.clusterpedia.io_pediaclusters.yaml
@@ -65,6 +65,64 @@ spec:
             properties:
               apiserver:
                 type: string
+              authenticationFrom:
+                properties:
+                  ca:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Namespace string `json:"namespace"`
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  cert:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Namespace string `json:"namespace"`
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  key:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Namespace string `json:"namespace"`
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  kubeconfig:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Namespace string `json:"namespace"`
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  token:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        description: Namespace string `json:"namespace"`
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                type: object
               caData:
                 format: byte
                 type: string

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -124,6 +124,7 @@ func (config completedConfig) New() (*ClusterPediaServer, error) {
 	resourceServerConfig.GenericConfig.ExternalAddress = config.GenericConfig.ExternalAddress
 	resourceServerConfig.GenericConfig.LoopbackClientConfig = config.GenericConfig.LoopbackClientConfig
 	resourceServerConfig.GenericConfig.TracerProvider = config.GenericConfig.TracerProvider
+	resourceServerConfig.GenericConfig.SharedInformerFactory = config.GenericConfig.SharedInformerFactory
 	resourceServerConfig.InformerFactory = clusterpediaInformerFactory
 	resourceServerConfig.StorageFactory = config.StorageFactory
 	resourceServerConfig.InitialAPIGroupResources = initialAPIGroupResources

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -13,6 +13,8 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
+		"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthentication":          schema_clusterpedia_io_api_cluster_v1alpha2_ClusterAuthentication(ref),
+		"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthenticationSource":    schema_clusterpedia_io_api_cluster_v1alpha2_ClusterAuthenticationSource(ref),
 		"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterGroupResources":          schema_clusterpedia_io_api_cluster_v1alpha2_ClusterGroupResources(ref),
 		"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterGroupResourcesStatus":    schema_clusterpedia_io_api_cluster_v1alpha2_ClusterGroupResourcesStatus(ref),
 		"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterResourceStatus":          schema_clusterpedia_io_api_cluster_v1alpha2_ClusterResourceStatus(ref),
@@ -24,6 +26,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterSyncResourcesSpec":       schema_clusterpedia_io_api_cluster_v1alpha2_ClusterSyncResourcesSpec(ref),
 		"github.com/clusterpedia-io/api/cluster/v1alpha2.PediaCluster":                   schema_clusterpedia_io_api_cluster_v1alpha2_PediaCluster(ref),
 		"github.com/clusterpedia-io/api/cluster/v1alpha2.PediaClusterList":               schema_clusterpedia_io_api_cluster_v1alpha2_PediaClusterList(ref),
+		"github.com/clusterpedia-io/api/cluster/v1alpha2.SecretKeySelector":              schema_clusterpedia_io_api_cluster_v1alpha2_SecretKeySelector(ref),
 		"github.com/clusterpedia-io/api/clusterpedia/v1beta1.CollectionResource":         schema_clusterpedia_io_api_clusterpedia_v1beta1_CollectionResource(ref),
 		"github.com/clusterpedia-io/api/clusterpedia/v1beta1.CollectionResourceList":     schema_clusterpedia_io_api_clusterpedia_v1beta1_CollectionResourceList(ref),
 		"github.com/clusterpedia-io/api/clusterpedia/v1beta1.CollectionResourceType":     schema_clusterpedia_io_api_clusterpedia_v1beta1_CollectionResourceType(ref),
@@ -96,6 +99,73 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"k8s.io/apimachinery/pkg/runtime.TypeMeta":                                       schema_k8sio_apimachinery_pkg_runtime_TypeMeta(ref),
 		"k8s.io/apimachinery/pkg/runtime.Unknown":                                        schema_k8sio_apimachinery_pkg_runtime_Unknown(ref),
 		"k8s.io/apimachinery/pkg/version.Info":                                           schema_k8sio_apimachinery_pkg_version_Info(ref),
+	}
+}
+
+func schema_clusterpedia_io_api_cluster_v1alpha2_ClusterAuthentication(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"kubeconfig": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthenticationSource"),
+						},
+					},
+					"ca": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthenticationSource"),
+						},
+					},
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthenticationSource"),
+						},
+					},
+					"cert": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthenticationSource"),
+						},
+					},
+					"token": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthenticationSource"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthenticationSource"},
+	}
+}
+
+func schema_clusterpedia_io_api_cluster_v1alpha2_ClusterAuthenticationSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace string `json:\"namespace\"`",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+				},
+				Required: []string{"name", "key"},
+			},
+		},
 	}
 }
 
@@ -349,6 +419,11 @@ func schema_clusterpedia_io_api_cluster_v1alpha2_ClusterSpec(ref common.Referenc
 							Format: "byte",
 						},
 					},
+					"authenticationFrom": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthentication"),
+						},
+					},
 					"syncResources": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
@@ -385,7 +460,7 @@ func schema_clusterpedia_io_api_cluster_v1alpha2_ClusterSpec(ref common.Referenc
 			},
 		},
 		Dependencies: []string{
-			"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterGroupResources"},
+			"github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterAuthentication", "github.com/clusterpedia-io/api/cluster/v1alpha2.ClusterGroupResources"},
 	}
 }
 
@@ -654,6 +729,34 @@ func schema_clusterpedia_io_api_cluster_v1alpha2_PediaClusterList(ref common.Ref
 		},
 		Dependencies: []string{
 			"github.com/clusterpedia-io/api/cluster/v1alpha2.PediaCluster", "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"},
+	}
+}
+
+func schema_clusterpedia_io_api_cluster_v1alpha2_SecretKeySelector(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace string `json:\"namespace\"`",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+				},
+				Required: []string{"name", "key"},
+			},
+		},
 	}
 }
 

--- a/pkg/kubeapiserver/resourcerest/proxy/proxy.go
+++ b/pkg/kubeapiserver/resourcerest/proxy/proxy.go
@@ -51,13 +51,13 @@ func proxyConn(ctx context.Context, connGetter ClusterConnectionGetter, upgradeR
 		// TODO(iceber): need disconnect when the cluster authentication information changes
 		endpoint, transport, err := connGetter.GetClusterConnection(ctx, clusterName, req)
 		if err != nil {
-			responder.Error(rw, req, err)
+			responder.Error(rw, req, apierrors.NewBadRequest(err.Error()))
 			return
 		}
 
 		target, err := url.ParseRequestURI(endpoint + req.URL.Path)
 		if err != nil {
-			responder.Error(rw, req, err)
+			responder.Error(rw, req, apierrors.NewBadRequest(err.Error()))
 			return
 		}
 

--- a/pkg/utils/rest.go
+++ b/pkg/utils/rest.go
@@ -2,14 +2,30 @@ package utils
 
 import (
 	"errors"
+	"fmt"
 
+	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	clusterv1alpha2 "github.com/clusterpedia-io/api/cluster/v1alpha2"
 )
 
-func BuildClusterRestConfig(cluster *clusterv1alpha2.PediaCluster) (*rest.Config, error) {
+func BuildClusterRestConfig(cluster *clusterv1alpha2.PediaCluster, lister v1.SecretNamespaceLister) (*rest.Config, error) {
+	// This is a simple and straightforward logic: authentication information is only retrieved
+	// from the Secret if no authentication fields are directly set in the Spec.
+	//
+	// Open to any modification suggestions based on user feedback.
+	if len(cluster.Spec.Kubeconfig) == 0 && len(cluster.Spec.TokenData) == 0 &&
+		(len(cluster.Spec.CertData) == 0 || len(cluster.Spec.KeyData) == 0) &&
+		cluster.Spec.AuthenticationFrom != nil {
+		config, err := buildClusterRestConfigFromSecret(cluster.Spec.APIServer, cluster.Spec.AuthenticationFrom, lister)
+		if err != nil {
+			return nil, fmt.Errorf("Cluster Authentication Error: %w", err)
+		}
+		return config, nil
+	}
+
 	if len(cluster.Spec.Kubeconfig) != 0 {
 		clientconfig, err := clientcmd.NewClientConfigFromBytes(cluster.Spec.Kubeconfig)
 		if err != nil {
@@ -46,4 +62,75 @@ func BuildClusterRestConfig(cluster *clusterv1alpha2.PediaCluster) (*rest.Config
 		config.BearerToken = string(cluster.Spec.TokenData)
 	}
 	return config, nil
+}
+
+// The logic is very direct. Awaiting more usage suggestions.
+func buildClusterRestConfigFromSecret(apiserver string, auth *clusterv1alpha2.ClusterAuthentication, lister v1.SecretNamespaceLister) (*rest.Config, error) {
+	if auth.KubeConfig != nil {
+		kubeconfig, err := getValueFromSecret(lister, auth.KubeConfig.Name, auth.KubeConfig.Key)
+		if err != nil {
+			return nil, err
+		}
+		clientconfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+		return clientconfig.ClientConfig()
+	}
+
+	if apiserver == "" {
+		return nil, errors.New("Cluster APIServer Endpoint is required")
+	}
+
+	if auth.Token == nil && (auth.Cert == nil || auth.Key == nil) {
+		return nil, errors.New("token or cert is required")
+	}
+
+	config := &rest.Config{
+		Host: apiserver,
+	}
+
+	if auth.CA != nil {
+		caData, err := getValueFromSecret(lister, auth.CA.Name, auth.CA.Key)
+		if err != nil {
+			return nil, err
+		}
+		config.TLSClientConfig.CAData = caData
+	} else {
+		config.TLSClientConfig.Insecure = true
+	}
+
+	if auth.CA != nil && auth.Key != nil {
+		cert, err := getValueFromSecret(lister, auth.Cert.Name, auth.Cert.Key)
+		if err != nil {
+			return nil, err
+		}
+		key, err := getValueFromSecret(lister, auth.Key.Name, auth.Key.Key)
+		if err != nil {
+			return nil, err
+		}
+		config.TLSClientConfig.CertData = cert
+		config.TLSClientConfig.KeyData = key
+	}
+
+	if auth.Token != nil {
+		token, err := getValueFromSecret(lister, auth.Token.Name, auth.Token.Key)
+		if err != nil {
+			return nil, err
+		}
+		config.BearerToken = string(token)
+	}
+	return config, nil
+}
+
+func getValueFromSecret(lister v1.SecretNamespaceLister, name string, key string) ([]byte, error) {
+	secret, err := lister.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	value := secret.Data[key]
+	if len(value) == 0 {
+		return nil, fmt.Errorf("secret %s's %s is empty", name, key)
+	}
+	return value, nil
 }

--- a/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
+++ b/staging/src/github.com/clusterpedia-io/api/cluster/v1alpha2/types.go
@@ -86,6 +86,8 @@ type ClusterSpec struct {
 	// +optional
 	KeyData []byte `json:"keyData,omitempty"`
 
+	AuthenticationFrom *ClusterAuthentication `json:"authenticationFrom,omitempty"`
+
 	// +required
 	SyncResources []ClusterGroupResources `json:"syncResources"`
 
@@ -97,6 +99,33 @@ type ClusterSpec struct {
 
 	// +optional
 	ShardingName string `json:"shardingName,omitempty"`
+}
+
+type ClusterAuthentication struct {
+	// +optional
+	KubeConfig *ClusterAuthenticationSource `json:"kubeconfig,omitempty"`
+
+	// +optional
+	CA *ClusterAuthenticationSource `json:"ca,omitempty"`
+
+	// +optional
+	Key *ClusterAuthenticationSource `json:"key,omitempty"`
+
+	// +optional
+	Cert *ClusterAuthenticationSource `json:"cert,omitempty"`
+
+	// +optional
+	Token *ClusterAuthenticationSource `json:"token,omitempty"`
+}
+
+type ClusterAuthenticationSource struct {
+	SecretKeySelector `json:",inline"`
+}
+
+type SecretKeySelector struct {
+	// Namespace string `json:"namespace"`
+	Name string `json:"name"`
+	Key  string `json:"key"`
 }
 
 type ClusterGroupResources struct {


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
Clusterpedia will only fetch secrets from the specified namespace, which is set by the --namespace flag, indicating the namespace where Clusterpedia is running.

```yaml
apiVersion: cluster.clusterpedia.io/v1alpha2
kind: PediaCluster
metadata:
  name: cluster-example
spec:
  apiserver: "https://cluster-example.io:8080"
  authenticationFrom:
    kubeconfig:
      name: "cluster-example-auth"
      key: "kubeconfig"
    ca:
      name: "cluster-example-auth"
      key: "ca.crt"
    cert:
      name: "cluster-example-auth"
      key: "client.crt"
    key:
      name: "cluster-example-auth"
      key: "client.key"
    token:
      name: "cluster-example-auth"
      key: "token"
```

**Which issue(s) this PR fixes**:
issue: https://github.com/clusterpedia-io/clusterpedia/issues/680

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
