### PR TITLE
kubeapiserver: allow using the storage version in request handling

### DIFF
--- a/pkg/kubeapiserver/apiserver.go
+++ b/pkg/kubeapiserver/apiserver.go
@@ -24,6 +24,7 @@ import (
 
 	informers "github.com/clusterpedia-io/clusterpedia/pkg/generated/informers/externalversions"
 	"github.com/clusterpedia-io/clusterpedia/pkg/kubeapiserver/discovery"
+	"github.com/clusterpedia-io/clusterpedia/pkg/kubeapiserver/features"
 	proxyrest "github.com/clusterpedia-io/clusterpedia/pkg/kubeapiserver/resourcerest/proxy"
 	"github.com/clusterpedia-io/clusterpedia/pkg/storage"
 	"github.com/clusterpedia-io/clusterpedia/pkg/utils/filters"
@@ -144,7 +145,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	discoveryManager := discovery.NewDiscoveryManager(c.GenericConfig.Serializer, restManager, delegate)
 
 	var secretLister corev1listers.SecretNamespaceLister
-	if utilfeature.DefaultFeatureGate.Enabled(ClusterAuthenticationFromSecret) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.ClusterAuthenticationFromSecret) {
 		secretLister = c.GenericConfig.SharedInformerFactory.Core().V1().Secrets().Lister().Secrets(c.ExtraConfig.SecretNamespace)
 	}
 

--- a/pkg/kubeapiserver/features/features.go
+++ b/pkg/kubeapiserver/features/features.go
@@ -1,4 +1,4 @@
-package kubeapiserver
+package features
 
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -18,6 +18,13 @@ const (
 	// owner: @scydas
 	// alpha: v0.9.0
 	ClusterAuthenticationFromSecret featuregate.Feature = "ClusterAuthenticationFromSecret"
+
+	// NotConvertToMemoryVersion could instaed of converting resources to memory version in request handling,
+	// it is permitted to use the storage version in some cases.
+
+	// owner: @Iceber
+	// alpha: v0.9.0
+	NotConvertToMemoryVersion featuregate.Feature = "NotConvertToMemoryVersion"
 )
 
 func init() {
@@ -29,4 +36,5 @@ func init() {
 var defaultInternalStorageFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AllowProxyRequestToClusters:     {Default: false, PreRelease: featuregate.Alpha},
 	ClusterAuthenticationFromSecret: {Default: false, PreRelease: featuregate.Alpha},
+	NotConvertToMemoryVersion:       {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/kubeapiserver/options.go
+++ b/pkg/kubeapiserver/options.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
+	"github.com/clusterpedia-io/clusterpedia/pkg/kubeapiserver/features"
 	proxyrest "github.com/clusterpedia-io/clusterpedia/pkg/kubeapiserver/resourcerest/proxy"
 )
 
@@ -67,9 +68,9 @@ var supportedProxyCoreSubresources = map[string][]string{
 }
 
 func (o *Options) Config() (*ExtraConfig, error) {
-	if !utilfeature.DefaultFeatureGate.Enabled(AllowProxyRequestToClusters) && (len(o.AllowedProxySubresources) != 0 ||
+	if !utilfeature.DefaultFeatureGate.Enabled(features.AllowProxyRequestToClusters) && (len(o.AllowedProxySubresources) != 0 ||
 		o.EnableProxyPathForForwardRequest || o.AllowForwardUnsyncResourceRequest) {
-		return nil, fmt.Errorf("please enable feature gate %s to allow apiserver to handle the proxy and forward requests", AllowProxyRequestToClusters)
+		return nil, fmt.Errorf("please enable feature gate %s to allow apiserver to handle the proxy and forward requests", features.AllowProxyRequestToClusters)
 	}
 
 	subresources := make(map[schema.GroupResource]sets.Set[string])

--- a/pkg/kubeapiserver/restmanager.go
+++ b/pkg/kubeapiserver/restmanager.go
@@ -385,14 +385,24 @@ func (m *RESTManager) genLegacyResourceRESTStorage(gvr schema.GroupVersionResour
 	}
 
 	return &resourcerest.RESTStorage{
+		StorageGVR:               resourceConfig.StorageResource,
 		DefaultQualifiedResource: gvr.GroupResource(),
 
-		NewFunc: func() runtime.Object {
+		NewMemoryFunc: func() runtime.Object {
 			obj, _ := scheme.LegacyResourceScheme.New(resourceConfig.MemoryResource.GroupVersion().WithKind(kind))
 			return obj
 		},
-		NewListFunc: func() runtime.Object {
+		NewMemoryListFunc: func() runtime.Object {
 			obj, _ := scheme.LegacyResourceScheme.New(resourceConfig.MemoryResource.GroupVersion().WithKind(kind + "List"))
+			return obj
+		},
+
+		NewStorageFunc: func() runtime.Object {
+			obj, _ := scheme.LegacyResourceScheme.New(resourceConfig.StorageResource.GroupVersion().WithKind(kind))
+			return obj
+		},
+		NewStorageListFunc: func() runtime.Object {
+			obj, _ := scheme.LegacyResourceScheme.New(resourceConfig.StorageResource.GroupVersion().WithKind(kind + "List"))
 			return obj
 		},
 
@@ -413,12 +423,12 @@ func (m *RESTManager) genUnstructuredRESTStorage(gvr schema.GroupVersionResource
 	}
 
 	return &resourcerest.RESTStorage{
-		NewFunc: func() runtime.Object {
+		NewMemoryFunc: func() runtime.Object {
 			obj := &unstructured.Unstructured{}
 			obj.SetGroupVersionKind(resourceConfig.MemoryResource.GroupVersion().WithKind(kind))
 			return obj
 		},
-		NewListFunc: func() runtime.Object {
+		NewMemoryListFunc: func() runtime.Object {
 			obj := &unstructured.UnstructuredList{}
 			obj.SetGroupVersionKind(resourceConfig.MemoryResource.GroupVersion().WithKind(kind + "List"))
 			return obj

--- a/pkg/utils/request/mediatype.go
+++ b/pkg/utils/request/mediatype.go
@@ -1,0 +1,24 @@
+package request
+
+import "context"
+
+type mediaTypeKeyType int
+
+const mediaTypeKindKey mediaTypeKeyType = iota
+
+func WithExtraMediaTypeKind(parent context.Context, kind string) context.Context {
+	if kind == "" {
+		return parent
+	}
+	return context.WithValue(parent, mediaTypeKindKey, kind)
+}
+
+func ExtraMediaTypeKindFrom(ctx context.Context) (string, bool) {
+	name, ok := ctx.Value(mediaTypeKindKey).(string)
+	return name, ok
+}
+
+func ExtraMediaTypeKindValue(ctx context.Context) string {
+	name, _ := ExtraMediaTypeKindFrom(ctx)
+	return name
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->
/kind feature

**What this PR does / why we need it**:
Using the version of the resource storaged in the storage layer can avoid extra version conversions between the decoded and encoded response data and the memory version.

However, according to testing, there is no very obvious optimization for request latency, but there is a slight optimization in CPU and memory usage, approximately 10% or more.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
