### PR TITLE
bump alpine to v3.21.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ ARG BIN_NAME
 ARG TARGETARCH
 RUN GOARCH=${TARGETARCH} /builder.sh ${BIN_NAME}
 
-FROM alpine:3.18.12
+# https://alpinelinux.org/releases/
+# Once we select a branch, we will continue to use the relevant version until it ends support.
+# The new branch selection must ensure that the patch version >= 3.
+FROM alpine:3.21.3
 RUN apk add --no-cache gcompat
 
 # https://pkg.go.dev/net#hdr-Name_Resolution


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind api-change
/kind bug
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake

-->

**What this PR does / why we need it**:
https://alpinelinux.org/releases/

v3.18 was unsupported as of 2025-05-09
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
