### PR TITLE
kubeapiserver: normalize pod portforward proxy subresource option

### DIFF
--- a/pkg/kubeapiserver/options.go
+++ b/pkg/kubeapiserver/options.go
@@ -62,29 +62,39 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 }
 
 var supportedProxyCoreSubresources = map[string][]string{
-	"pods":     {"proxy", "log", "exec", "attach", "portfowrd"},
+	"pods":     {"proxy", "log", "exec", "attach", "portforward"},
 	"nodes":    {"proxy"},
 	"services": {"proxy"},
 }
 
-func (o *Options) Config() (*ExtraConfig, error) {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.AllowProxyRequestToClusters) && (len(o.AllowedProxySubresources) != 0 ||
-		o.EnableProxyPathForForwardRequest || o.AllowForwardUnsyncResourceRequest) {
-		return nil, fmt.Errorf("please enable feature gate %s to allow apiserver to handle the proxy and forward requests", features.AllowProxyRequestToClusters)
-	}
+// TODO(Iceber): remove the legacy portfowrd alias in 1.0.
+var proxySubresourceAliases = map[string]string{
+	"portfowrd": "portforward",
+}
 
+func normalizeProxySubresourceName(name string) string {
+	if canonical, ok := proxySubresourceAliases[name]; ok {
+		return canonical
+	}
+	return name
+}
+
+func parseAllowedProxySubresources(allowed []string) (map[schema.GroupResource]sets.Set[string], error) {
 	subresources := make(map[schema.GroupResource]sets.Set[string])
 
-	for _, subresource := range o.AllowedProxySubresources {
+	for _, subresource := range allowed {
+		raw := strings.TrimSpace(subresource)
 		var resource string
-		switch slice := strings.Split(strings.TrimSpace(subresource), "/"); len(slice) {
+		switch slice := strings.Split(raw, "/"); len(slice) {
 		case 1:
 			subresource = slice[0]
 		case 2:
 			resource, subresource = slice[0], slice[1]
 		default:
-			return nil, fmt.Errorf("--allowed-proxy-subresources: invalid format %q", subresource)
+			return nil, fmt.Errorf("--allowed-proxy-subresources: invalid format %q", raw)
 		}
+
+		subresource = normalizeProxySubresourceName(subresource)
 
 		var matched bool
 		for r, srs := range supportedProxyCoreSubresources {
@@ -103,8 +113,21 @@ func (o *Options) Config() (*ExtraConfig, error) {
 			}
 		}
 		if !matched {
-			return nil, fmt.Errorf("--allowed-proxy-subresources: unsupported subresources or invalid format %q", subresource)
+			return nil, fmt.Errorf("--allowed-proxy-subresources: unsupported subresources or invalid format %q", raw)
 		}
+	}
+	return subresources, nil
+}
+
+func (o *Options) Config() (*ExtraConfig, error) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.AllowProxyRequestToClusters) && (len(o.AllowedProxySubresources) != 0 ||
+		o.EnableProxyPathForForwardRequest || o.AllowForwardUnsyncResourceRequest) {
+		return nil, fmt.Errorf("please enable feature gate %s to allow apiserver to handle the proxy and forward requests", features.AllowProxyRequestToClusters)
+	}
+
+	subresources, err := parseAllowedProxySubresources(o.AllowedProxySubresources)
+	if err != nil {
+		return nil, err
 	}
 	return &ExtraConfig{
 		AllowPediaClusterConfigReuse:      o.AllowPediaClusterConfigForProxyRequest,

--- a/pkg/kubeapiserver/options_test.go
+++ b/pkg/kubeapiserver/options_test.go
@@ -1,0 +1,80 @@
+package kubeapiserver
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestParseAllowedProxySubresources(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowed     []string
+		wantError   bool
+		wantErrText string
+		wantHasPods []string
+	}{
+		{
+			name:        "canonical portforward",
+			allowed:     []string{"pods/portforward"},
+			wantHasPods: []string{"portforward"},
+		},
+		{
+			name:        "legacy typo alias",
+			allowed:     []string{"pods/portfowrd"},
+			wantHasPods: []string{"portforward"},
+		},
+		{
+			name:        "resource omitted",
+			allowed:     []string{"portforward"},
+			wantHasPods: []string{"portforward"},
+		},
+		{
+			name:        "unsupported subresource",
+			allowed:     []string{"pods/trace"},
+			wantError:   true,
+			wantErrText: `"pods/trace"`,
+		},
+		{
+			name:        "unsupported resource keeps resource in error",
+			allowed:     []string{"foo/portforward"},
+			wantError:   true,
+			wantErrText: `"foo/portforward"`,
+		},
+		{
+			name:        "invalid format keeps original token in error",
+			allowed:     []string{"pods/log/extra"},
+			wantError:   true,
+			wantErrText: `"pods/log/extra"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseAllowedProxySubresources(test.allowed)
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if test.wantErrText != "" && !strings.Contains(err.Error(), test.wantErrText) {
+					t.Fatalf("expected error to contain %s, got %q", test.wantErrText, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			pods := got[schema.GroupResource{Resource: "pods"}]
+			if pods == nil {
+				t.Fatalf("expected pods subresources to be present")
+			}
+			for _, want := range test.wantHasPods {
+				if !pods.Has(want) {
+					t.Fatalf("expected pods subresources to contain %q, got %v", want, pods.UnsortedList())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The proxy REST layer registers `pods/portforward`, but `--allowed-proxy-subresources` only advertised and validated the misspelled `portfowrd` token. That left the feature unusable through the flag path: the correct spelling was rejected, while the accepted typo never matched the actual registered subresource.

This change makes `portforward` the canonical pod subresource name, keeps `portfowrd` as a compatibility alias, and adds unit tests around the parser.

**Which issue(s) this PR fixes**:
Fixes #829

**Special notes for your reviewer**:

Validated with:
- `go test ./pkg/kubeapiserver/... -count=1`
- `go test ./pkg/... -count=1`

**Does this PR introduce a user-facing change?**:
```release-note
Fixed `--allowed-proxy-subresources` so pod `portforward` proxying can be enabled with `pods/portforward`, while the historical `pods/portfowrd` typo remains accepted as a compatibility alias.
```
