### PR TITLE
apiserver: parse label selector when trimming the forward label

### DIFF
--- a/pkg/kubeapiserver/resource_handler.go
+++ b/pkg/kubeapiserver/resource_handler.go
@@ -215,8 +215,10 @@ func checkClusterAndWarning(ctx context.Context, cluster *clusterv1alpha2.PediaC
 //
 // The selector is parsed so that embedded commas in set-notation values
 // (e.g. "key in (v1,v2)") and labels whose keys merely share the
-// SearchLabelForwardRequest prefix are handled correctly, and so that the
-// returned string is always a valid label selector.
+// SearchLabelForwardRequest prefix are handled correctly. If parsing fails,
+// the original selector is returned unchanged with false. Only selectors
+// that are successfully parsed and rebuilt are guaranteed to round-trip to a
+// valid label selector.
 func trimForwardLabelForLabelSelectorQuery(selector string) (string, bool) {
 	parsed, err := labels.Parse(selector)
 	if err != nil {

--- a/pkg/kubeapiserver/resource_handler.go
+++ b/pkg/kubeapiserver/resource_handler.go
@@ -220,6 +220,10 @@ func checkClusterAndWarning(ctx context.Context, cluster *clusterv1alpha2.PediaC
 // that are successfully parsed and rebuilt are guaranteed to round-trip to a
 // valid label selector.
 func trimForwardLabelForLabelSelectorQuery(selector string) (string, bool) {
+	if !strings.Contains(selector, clusterpedia.SearchLabelForwardRequest) {
+		return selector, false
+	}
+
 	parsed, err := labels.Parse(selector)
 	if err != nil {
 		return selector, false

--- a/pkg/kubeapiserver/resource_handler.go
+++ b/pkg/kubeapiserver/resource_handler.go
@@ -10,6 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
@@ -208,17 +209,35 @@ func checkClusterAndWarning(ctx context.Context, cluster *clusterv1alpha2.PediaC
 	}
 }
 
-var forwardLabelLength = len(clusterpedia.SearchLabelForwardRequest)
-
+// trimForwardLabelForLabelSelectorQuery removes the SearchLabelForwardRequest
+// requirement from a label selector query string. It returns the rewritten
+// selector and a boolean indicating whether the forward label was present.
+//
+// The selector is parsed so that embedded commas in set-notation values
+// (e.g. "key in (v1,v2)") and labels whose keys merely share the
+// SearchLabelForwardRequest prefix are handled correctly, and so that the
+// returned string is always a valid label selector.
 func trimForwardLabelForLabelSelectorQuery(selector string) (string, bool) {
-	if i := strings.Index(selector, clusterpedia.SearchLabelForwardRequest); i != -1 {
-		l, other := selector[:i], selector[i+forwardLabelLength:]
-		if i := strings.Index(other, ","); i != -1 {
-			l += other[i:]
-		}
-		return strings.TrimPrefix(strings.TrimSuffix(l, ","), ","), true
+	parsed, err := labels.Parse(selector)
+	if err != nil {
+		return selector, false
 	}
-	return selector, false
+
+	requirements, _ := parsed.Requirements()
+	kept := make([]labels.Requirement, 0, len(requirements))
+	var trimmed bool
+	for _, req := range requirements {
+		if req.Key() == clusterpedia.SearchLabelForwardRequest {
+			trimmed = true
+			continue
+		}
+		kept = append(kept, req)
+	}
+
+	if !trimmed {
+		return selector, false
+	}
+	return labels.NewSelector().Add(kept...).String(), true
 }
 
 func HasForwardRequestHeader(req *http.Request) bool {

--- a/pkg/kubeapiserver/resource_handler_test.go
+++ b/pkg/kubeapiserver/resource_handler_test.go
@@ -1,0 +1,117 @@
+package kubeapiserver
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestTrimForwardLabelForLabelSelectorQuery(t *testing.T) {
+	tests := []struct {
+		name        string
+		selector    string
+		wantResult  string
+		wantTrimmed bool
+	}{
+		{
+			name:        "empty selector is returned unchanged",
+			selector:    "",
+			wantResult:  "",
+			wantTrimmed: false,
+		},
+		{
+			name:        "selector without forward label is returned unchanged",
+			selector:    "foo=bar",
+			wantResult:  "foo=bar",
+			wantTrimmed: false,
+		},
+		{
+			name:        "forward label alone is trimmed to empty",
+			selector:    "search.clusterpedia.io/forward",
+			wantResult:  "",
+			wantTrimmed: true,
+		},
+		{
+			name:        "forward label with equality is trimmed",
+			selector:    "search.clusterpedia.io/forward=true",
+			wantResult:  "",
+			wantTrimmed: true,
+		},
+		{
+			name:        "forward label leading is trimmed",
+			selector:    "search.clusterpedia.io/forward,foo=bar",
+			wantResult:  "foo=bar",
+			wantTrimmed: true,
+		},
+		{
+			name:        "forward label trailing is trimmed",
+			selector:    "foo=bar,search.clusterpedia.io/forward",
+			wantResult:  "foo=bar",
+			wantTrimmed: true,
+		},
+		{
+			// Regression: previously returned "foo=bar,,baz=qux" which is not a
+			// valid label selector.
+			name:        "forward label in middle does not introduce empty requirements",
+			selector:    "foo=bar,search.clusterpedia.io/forward,baz=qux",
+			wantResult:  "baz=qux,foo=bar",
+			wantTrimmed: true,
+		},
+		{
+			// Regression: previously returned "a=1,,b=2".
+			name:        "forward label with value in middle does not introduce empty requirements",
+			selector:    "a=1,search.clusterpedia.io/forward=true,b=2",
+			wantResult:  "a=1,b=2",
+			wantTrimmed: true,
+		},
+		{
+			// Regression: previously matched as a substring and dropped a
+			// different label whose key happens to share the forward prefix.
+			name:        "label sharing the forward prefix is preserved",
+			selector:    "a=1,search.clusterpedia.io/forward-something=true",
+			wantResult:  "a=1,search.clusterpedia.io/forward-something=true",
+			wantTrimmed: false,
+		},
+		{
+			// Regression: commas inside set-notation values must not be mistaken
+			// for requirement separators.
+			name:        "set notation with commas around forward label",
+			selector:    "env in (prod,stage),search.clusterpedia.io/forward,tier=frontend",
+			wantResult:  "env in (prod,stage),tier=frontend",
+			wantTrimmed: true,
+		},
+		{
+			name:        "forward label with exists requirement among others",
+			selector:    "a=1,b!=2,search.clusterpedia.io/forward",
+			wantResult:  "a=1,b!=2",
+			wantTrimmed: true,
+		},
+		{
+			name:        "invalid selector is returned unchanged",
+			selector:    ",,,",
+			wantResult:  ",,,",
+			wantTrimmed: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, trimmed := trimForwardLabelForLabelSelectorQuery(test.selector)
+			if trimmed != test.wantTrimmed {
+				t.Errorf("expected trimmed=%v, got %v", test.wantTrimmed, trimmed)
+			}
+			if got != test.wantResult {
+				t.Errorf("expected result %q, got %q", test.wantResult, got)
+			}
+
+			// The returned selector must always be a valid label selector when
+			// the input selector was valid, so that downstream decoders can
+			// parse it without a syntax error.
+			if _, err := labels.Parse(test.selector); err == nil {
+				if _, err := labels.Parse(got); err != nil {
+					t.Errorf("returned selector %q is not parseable: %v", got, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/kubeapiserver/resource_handler_test.go
+++ b/pkg/kubeapiserver/resource_handler_test.go
@@ -92,6 +92,12 @@ func TestTrimForwardLabelForLabelSelectorQuery(t *testing.T) {
 			wantResult:  ",,,",
 			wantTrimmed: false,
 		},
+		{
+			name:        "invalid selector containing forward label is returned unchanged",
+			selector:    "foo=bar,search.clusterpedia.io/forward in (",
+			wantResult:  "foo=bar,search.clusterpedia.io/forward in (",
+			wantTrimmed: false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`trimForwardLabelForLabelSelectorQuery` in `pkg/kubeapiserver/resource_handler.go` is invoked on every list/watch request to strip `search.clusterpedia.io/forward` from the `labelSelector` query parameter and decide whether the request should be forwarded to a member cluster. The existing implementation uses `strings.Index` plus slice concatenation, which produces malformed selectors whenever the forward label appears between other requirements.

Example: `foo=bar,search.clusterpedia.io/forward,baz=qux` becomes `foo=bar,,baz=qux`, which `labels.Parse` rejects with:

```
found ',', expected: identifier after ','
```

The trimmed selector is written back into the request query via `query.Set("labelSelector", ...)` and is decoded downstream by `scheme.ParameterCodec.DecodeParameters`, so the request fails with `Bad Request` instead of being forwarded. Substring matching also drops unrelated labels that share the `search.clusterpedia.io/forward` prefix, and a naive comma split would mishandle set-notation values such as `key in (v1,v2)`.

This PR replaces the string trimmer with a selector-aware implementation that:

1. Parses the selector with `k8s.io/apimachinery/pkg/labels`, falling back to returning the original string unmodified when the input is not a valid selector.
2. Drops the single requirement whose key equals `SearchLabelForwardRequest`.
3. Re-serializes the kept requirements via `labels.NewSelector` so the returned string is always a valid label selector and set-notation values are preserved.

A new `resource_handler_test.go` adds table-driven coverage for the regressions (forward label in the middle of the selector, prefix-sharing labels, set-notation values) alongside the previously working cases.

**Which issue(s) this PR fixes**:
Fixes #853

**Special notes for your reviewer**:

- The behavioural contract of the function is preserved: any occurrence of `search.clusterpedia.io/forward` as a requirement key still triggers forwarding and is removed from the selector.
- Labels whose keys only share the forward prefix (e.g. a hypothetical `search.clusterpedia.io/forward-something`) are no longer mistakenly stripped. That is a bug fix rather than a behaviour change.
- `labels.NewSelector().Add(...).String()` emits requirements in canonical (sorted) order; the resulting selector is still semantically equivalent and parses the same way.
- Verified with `go test -race -cover ./pkg/...` and `golangci-lint run ./pkg/kubeapiserver/...`.

**Does this PR introduce a user-facing change?**:

```release-note
Fix list/watch requests with `search.clusterpedia.io/forward` combined with other label requirements being rejected with "found ',', expected: identifier after ','". The forward label is now parsed out of the label selector correctly and unrelated labels that share its key prefix are preserved.
```
