### PR TITLE
storage: reject negative owner seniority

### DIFF
--- a/pkg/storage/internalstorage/resource_storage.go
+++ b/pkg/storage/internalstorage/resource_storage.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/watch"
 	genericstorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/client-go/tools/cache"
@@ -379,6 +380,16 @@ func applyListOptionsToResourceQuery(db *gorm.DB, query *gorm.DB, opts *internal
 }
 
 func applyOwnerToResourceQuery(db *gorm.DB, query *gorm.DB, opts *internal.ListOptions) (*gorm.DB, error) {
+	if opts.OwnerSeniority < 0 {
+		return nil, apierrors.NewInvalid(
+			schema.GroupKind{Group: internal.GroupName, Kind: "ListOptions"},
+			"ownerSeniority",
+			field.ErrorList{
+				field.Invalid(field.NewPath("ownerSeniority"), opts.OwnerSeniority, "must be non-negative"),
+			},
+		)
+	}
+
 	var ownerQuery interface{}
 	switch {
 	case len(opts.ClusterNames) != 1:

--- a/pkg/storage/internalstorage/resource_storage_test.go
+++ b/pkg/storage/internalstorage/resource_storage_test.go
@@ -186,6 +186,19 @@ func TestApplyListOptionsToResourceQuery_Owner(t *testing.T) {
 	}
 }
 
+func TestApplyOwnerToResourceQueryRejectsNegativeOwnerSeniority(t *testing.T) {
+	query := postgresDB.Session(&gorm.Session{DryRun: true}).Model(&Resource{})
+	_, err := applyOwnerToResourceQuery(postgresDB, query, &internal.ListOptions{
+		ClusterNames:   []string{"cluster-1"},
+		OwnerUID:       "owner-uid-1",
+		OwnerSeniority: -1,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ownerSeniority")
+	assert.Contains(t, err.Error(), "must be non-negative")
+}
+
 func TestResourceStorage_genGetObjectQuery(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion.go
@@ -185,6 +185,9 @@ func Convert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in *ListOptions, ou
 			out.ExtraLabelSelector = labels.NewSelector().Add(extraLabelRequest...)
 		}
 	}
+	if out.OwnerSeniority < 0 {
+		return fmt.Errorf("Invalid Query OwnerSeniority(%d): must be non-negative", out.OwnerSeniority)
+	}
 	if out.Before.Before(out.Since) {
 		return fmt.Errorf("Invalid Query, Since is after Before")
 	}

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion_test.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion_test.go
@@ -1,0 +1,36 @@
+package v1beta1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/clusterpedia-io/api/clusterpedia"
+)
+
+func TestConvertListOptionsRejectsNegativeOwnerSeniority(t *testing.T) {
+	in := &ListOptions{OwnerSeniority: -1}
+	out := &clusterpedia.ListOptions{}
+
+	err := Convert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in, out, nil)
+	if err == nil {
+		t.Fatal("expected negative ownerSeniority to be rejected")
+	}
+	if !strings.Contains(err.Error(), "OwnerSeniority(-1)") {
+		t.Fatalf("expected error to include ownerSeniority value, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "must be non-negative") {
+		t.Fatalf("expected non-negative validation error, got %q", err.Error())
+	}
+}
+
+func TestConvertListOptionsAcceptsNonNegativeOwnerSeniority(t *testing.T) {
+	in := &ListOptions{OwnerSeniority: 1}
+	out := &clusterpedia.ListOptions{}
+
+	if err := Convert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in, out, nil); err != nil {
+		t.Fatalf("expected non-negative ownerSeniority to be accepted, got %v", err)
+	}
+	if out.OwnerSeniority != 1 {
+		t.Fatalf("expected ownerSeniority to be converted, got %d", out.OwnerSeniority)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Rejects negative `ownerSeniority` values during v1beta1 list-option conversion so invalid owner-search requests fail before reaching storage query construction.

Adds a defensive internal storage validation before recursive owner query builders are called, so programmatic callers cannot trigger unbounded recursion with a negative seniority value.

**Which issue(s) this PR fixes**:
Fixes #858

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:
```release-note
Reject negative ownerSeniority list queries instead of allowing owner search query construction to recurse indefinitely.
```
