### PR TITLE
fix: prevent infinite recursion with negative ownerSeniority

### DIFF
--- a/pkg/storage/internalstorage/json_builder.go
+++ b/pkg/storage/internalstorage/json_builder.go
@@ -212,7 +212,7 @@ func writeString(builder clause.Writer, str string) {
 }
 
 func buildOwnerQueryByUID(db *gorm.DB, cluster, uid string, seniority int) interface{} {
-	if seniority == 0 {
+	if seniority <= 0 {
 		return uid
 	}
 
@@ -226,7 +226,7 @@ func buildOwnerQueryByUID(db *gorm.DB, cluster, uid string, seniority int) inter
 
 func buildOwnerQueryByName(db *gorm.DB, cluster string, namespaces []string, groupResource schema.GroupResource, name string, seniority int) interface{} {
 	ownerQuery := db.Model(Resource{}).Select("uid").Where(map[string]interface{}{"cluster": cluster})
-	if seniority != 0 {
+	if seniority > 0 {
 		parentOwner := buildOwnerQueryByName(db, cluster, namespaces, groupResource, name, seniority-1)
 		return ownerQuery.Where("owner_uid IN (?)", parentOwner)
 	}

--- a/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion.go
+++ b/staging/src/github.com/clusterpedia-io/api/clusterpedia/v1beta1/conversion.go
@@ -112,6 +112,9 @@ func Convert_v1beta1_ListOptions_To_clusterpedia_ListOptions(in *ListOptions, ou
 						if err != nil {
 							return fmt.Errorf("Invalid Query OwnerSeniority(%s): %w", values[0], err)
 						}
+						if seniority < 0 {
+							return fmt.Errorf("Invalid Query OwnerSeniority(%s): must be non-negative", values[0])
+						}
 						out.OwnerSeniority = seniority
 					}
 				case clusterpedia.SearchLabelSince:


### PR DESCRIPTION
Fixes #858

Negative `ownerSeniority` values cause infinite recursion in `buildOwnerQueryByUID` and `buildOwnerQueryByName` because the termination condition only checks for zero. Changed both to `<= 0` / `> 0` and added an early return in `conversion.go` to reject negative values before they reach the storage layer.