### PR TITLE
internalstorage: add database operation metrics

### DIFF
--- a/pkg/storage/internalstorage/operation_metrics.go
+++ b/pkg/storage/internalstorage/operation_metrics.go
@@ -1,0 +1,132 @@
+package internalstorage
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"gorm.io/gorm"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+// opStartTimeKey is the GORM instance setting that carries an operation's start
+// time from its before callback to its after callback.
+const opStartTimeKey = "clusterpedia:operation_start"
+
+var _ gorm.Plugin = &operationMetrics{}
+
+// operationMetrics is a gorm.Plugin that records the count and latency of
+// database operations (create/query/update/delete/row/raw) via GORM callbacks.
+// It complements the connection-pool metrics provided by Prometheus.
+type operationMetrics struct {
+	dbName   string
+	total    *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+}
+
+// NewGormOperationMetrics builds the operation-metrics plugin. dbName is attached
+// as a const label so metrics from multiple databases can be told apart. The
+// collectors are created and registered in Initialize, matching Prometheus.
+func NewGormOperationMetrics(dbName string) gorm.Plugin {
+	return &operationMetrics{dbName: dbName}
+}
+
+// Name implements gorm.Plugin.
+func (m *operationMetrics) Name() string {
+	return "gorm:clusterpedia-operation-metrics"
+}
+
+// Initialize implements gorm.Plugin. It registers the collectors and hooks the
+// per-operation callbacks.
+func (m *operationMetrics) Initialize(db *gorm.DB) error {
+	labels := prometheus.Labels{"db_name": m.dbName}
+	m.total = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem:   "storage",
+		Name:        "operation_total",
+		Help:        "Total number of database operations, by operation and status.",
+		ConstLabels: labels,
+	}, []string{"operation", "status"})
+	m.duration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem:   "storage",
+		Name:        "operation_duration_seconds",
+		Help:        "Latency of database operations in seconds, by operation.",
+		ConstLabels: labels,
+		Buckets:     prometheus.DefBuckets,
+	}, []string{"operation"})
+	legacyregistry.RawMustRegister(m.total, m.duration)
+
+	return m.registerCallbacks(db)
+}
+
+// registerCallbacks hooks a before callback that stamps the start time and an
+// after callback that records the result for each operation.
+func (m *operationMetrics) registerCallbacks(db *gorm.DB) error {
+	cb := db.Callback()
+	hooks := []struct {
+		before    gormRegister
+		after     gormRegister
+		operation string
+	}{
+		{cb.Create().Before("gorm:create"), cb.Create().After("gorm:create"), "create"},
+		{cb.Query().Before("gorm:query"), cb.Query().After("gorm:query"), "query"},
+		{cb.Update().Before("gorm:update"), cb.Update().After("gorm:update"), "update"},
+		{cb.Delete().Before("gorm:delete"), cb.Delete().After("gorm:delete"), "delete"},
+		{cb.Row().Before("gorm:row"), cb.Row().After("gorm:row"), "row"},
+		{cb.Raw().Before("gorm:raw"), cb.Raw().After("gorm:raw"), "raw"},
+	}
+
+	var firstErr error
+	for _, h := range hooks {
+		if err := h.before.Register("clusterpedia:metrics:before:"+h.operation, recordOperationStart); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("register before:%s metrics callback: %w", h.operation, err)
+		}
+		if err := h.after.Register("clusterpedia:metrics:after:"+h.operation, m.recordOperation(h.operation)); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("register after:%s metrics callback: %w", h.operation, err)
+		}
+	}
+	return firstErr
+}
+
+// recordOperationStart stamps the operation's start time for recordOperation.
+func recordOperationStart(tx *gorm.DB) {
+	tx.InstanceSet(opStartTimeKey, time.Now())
+}
+
+// recordOperation returns an after callback that increments the operation
+// counter and observes its latency.
+func (m *operationMetrics) recordOperation(operation string) gormHookFunc {
+	return func(tx *gorm.DB) {
+		status := "success"
+		if isOperationError(tx.Error) {
+			status = "error"
+		}
+		m.total.WithLabelValues(operation, status).Inc()
+
+		if v, ok := tx.InstanceGet(opStartTimeKey); ok {
+			if start, ok := v.(time.Time); ok {
+				m.duration.WithLabelValues(operation).Observe(time.Since(start).Seconds())
+			}
+		}
+	}
+}
+
+// isOperationError reports whether err is a real database failure. Expected
+// "no rows" outcomes are not counted as errors, matching the tracing plugin.
+func isOperationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound),
+		errors.Is(err, driver.ErrSkip),
+		errors.Is(err, io.EOF),
+		errors.Is(err, sql.ErrNoRows):
+		return false
+	default:
+		return true
+	}
+}

--- a/pkg/storage/internalstorage/operation_metrics_test.go
+++ b/pkg/storage/internalstorage/operation_metrics_test.go
@@ -1,0 +1,68 @@
+package internalstorage
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// newTestOperationMetrics builds an operationMetrics with un-registered
+// collectors so the test does not touch the global registry.
+func newTestOperationMetrics() *operationMetrics {
+	labels := prometheus.Labels{"db_name": "test"}
+	return &operationMetrics{
+		total: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Subsystem: "storage", Name: "operation_total", ConstLabels: labels,
+		}, []string{"operation", "status"}),
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Subsystem: "storage", Name: "operation_duration_seconds", ConstLabels: labels,
+			Buckets: prometheus.DefBuckets,
+		}, []string{"operation"}),
+	}
+}
+
+func TestOperationMetrics(t *testing.T) {
+	db, cleanup, err := newSQLiteDB()
+	if err != nil {
+		t.Fatalf("newSQLiteDB() failed: %v", err)
+	}
+	defer cleanup()
+
+	// Wire the callbacks directly so the test does not register collectors on
+	// the global registry (Initialize would).
+	m := newTestOperationMetrics()
+	if err := m.registerCallbacks(db); err != nil {
+		t.Fatalf("register operation metrics callbacks: %v", err)
+	}
+
+	// A successful query is counted under query/success.
+	var resources []Resource
+	if err := db.Find(&resources).Error; err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if got := testutil.ToFloat64(m.total.WithLabelValues("query", "success")); got != 1 {
+		t.Errorf("query success count = %v, want 1", got)
+	}
+
+	// A failing query (unknown table) is counted under query/error.
+	if err := db.Table("does_not_exist").Find(&resources).Error; err == nil {
+		t.Fatal("expected query against unknown table to fail")
+	}
+	if got := testutil.ToFloat64(m.total.WithLabelValues("query", "error")); got != 1 {
+		t.Errorf("query error count = %v, want 1", got)
+	}
+
+	// Exec runs through the raw callback and is counted under raw/success.
+	if err := db.Exec("SELECT 1").Error; err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if got := testutil.ToFloat64(m.total.WithLabelValues("raw", "success")); got != 1 {
+		t.Errorf("raw success count = %v, want 1", got)
+	}
+
+	// Latency is observed for the operations that ran.
+	if got := testutil.CollectAndCount(m.duration); got == 0 {
+		t.Error("operation duration histogram recorded no samples")
+	}
+}

--- a/pkg/storage/internalstorage/register.go
+++ b/pkg/storage/internalstorage/register.go
@@ -86,6 +86,9 @@ func NewStorageFactory(configPath string) (storage.StorageFactory, error) {
 		if err := db.Use(NewGormMetrics(cfg.Database, cfg.Metrics.DBStatsRefreshInterval)); err != nil {
 			return nil, err
 		}
+		if err := db.Use(NewGormOperationMetrics(cfg.Database)); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := db.Use(NewGormTrace(false)); err != nil {


### PR DESCRIPTION
Addresses #699.

The storage layer already exposes connection-pool metrics (`storage_dbstats_*`), but nothing about the database operations themselves, so it's hard to see the load `clustersynchro-manager` and the apiserver put on the database. This adds that.

I added a GORM plugin that hooks the create/query/update/delete/row/raw callbacks (same way `tracing.go` does) and records two metrics per operation:

- `storage_operation_total{operation,status}` — count, with `status` either `success` or `error`
- `storage_operation_duration_seconds{operation}` — latency

A "record not found" (and the other expected no-rows outcomes the tracing plugin already ignores) is counted as success rather than an error. The plugin carries the same `db_name` const label as the existing DBStats metrics, and is registered next to them under the same `metrics.disable` switch, so there's no new config.

I kept this separate from the resource-synchro metrics added in #718 — those count resource operations at the sync layer, whereas this is about actual database load.

Tested with a unit test that drives the callbacks against a sqlite DB and checks the success/error counters and the latency histogram. `go build ./...`, `go vet` and the package tests pass.

I'm happy to adjust the metric names/labels or the approach if you'd prefer something different.
