### PR TITLE
apiserver: add HTTP request metrics

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -139,6 +139,7 @@ func (config completedConfig) New() (*ClusterPediaServer, error) {
 		handler := handlerChainFunc(apiHandler, c)
 		handler = filters.WithRequestQuery(handler)
 		handler = filters.WithAcceptHeader(handler)
+		handler = filters.WithRequestMetrics(handler, c.RequestInfoResolver)
 		return handler
 	}
 

--- a/pkg/metrics/request.go
+++ b/pkg/metrics/request.go
@@ -1,0 +1,74 @@
+package metrics
+
+import (
+	"strconv"
+	"time"
+
+	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const apiserverSubsystem = "clusterpedia_apiserver"
+
+var (
+	requestTotal = compbasemetrics.NewCounterVec(
+		&compbasemetrics.CounterOpts{
+			Subsystem: apiserverSubsystem,
+			Name:      "request_total",
+			Help:      "Counter of HTTP requests processed by Clusterpedia APIServer, broken out by status code, handler and method.",
+		},
+		[]string{"code", "handler", "method"},
+	)
+
+	requestDuration = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Subsystem: apiserverSubsystem,
+			Name:      "request_duration_seconds",
+			Help:      "Response latency distribution in seconds for Clusterpedia APIServer, broken out by status code, handler and method.",
+			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+		},
+		[]string{"code", "handler", "method"},
+	)
+
+	responseSize = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Subsystem: apiserverSubsystem,
+			Name:      "response_size_bytes",
+			Help:      "Response size distribution in bytes for Clusterpedia APIServer, broken out by status code, handler and method.",
+			Buckets:   compbasemetrics.ExponentialBuckets(100, 10, 8),
+		},
+		[]string{"code", "handler", "method"},
+	)
+
+	requestInflight = compbasemetrics.NewGaugeVec(
+		&compbasemetrics.GaugeOpts{
+			Subsystem: apiserverSubsystem,
+			Name:      "request_inflight",
+			Help:      "Number of HTTP requests currently being processed by Clusterpedia APIServer, broken out by handler.",
+		},
+		[]string{"handler"},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(requestTotal)
+	legacyregistry.MustRegister(requestDuration)
+	legacyregistry.MustRegister(responseSize)
+	legacyregistry.MustRegister(requestInflight)
+}
+
+func IncInflight(handler string) {
+	requestInflight.WithLabelValues(handler).Inc()
+}
+
+func DecInflight(handler string) {
+	requestInflight.WithLabelValues(handler).Dec()
+}
+
+// RecordRequest records count, latency and response size for a finished request.
+func RecordRequest(code int, method, handler string, duration time.Duration, size int) {
+	codeStr := strconv.Itoa(code)
+	requestTotal.WithLabelValues(codeStr, handler, method).Inc()
+	requestDuration.WithLabelValues(codeStr, handler, method).Observe(duration.Seconds())
+	responseSize.WithLabelValues(codeStr, handler, method).Observe(float64(size))
+}

--- a/pkg/utils/filters/metrics.go
+++ b/pkg/utils/filters/metrics.go
@@ -1,0 +1,117 @@
+package filters
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/clusterpedia-io/clusterpedia/pkg/metrics"
+)
+
+// WithRequestMetrics records request count, duration, response size and
+// in-flight gauges for the Clusterpedia APIServer.
+//
+// resolver builds a low-cardinality handler label from the request path
+// (resource type rather than object name). It may be nil.
+func WithRequestMetrics(handler http.Handler, resolver genericrequest.RequestInfoResolver) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		start := time.Now()
+		name := resolveHandlerLabel(req, resolver)
+
+		metrics.IncInflight(name)
+		defer metrics.DecInflight(name)
+
+		rw := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+		handler.ServeHTTP(rw, req)
+
+		metrics.RecordRequest(rw.status, req.Method, name, time.Since(start), rw.bytes)
+	})
+}
+
+func resolveHandlerLabel(req *http.Request, resolver genericrequest.RequestInfoResolver) string {
+	if resolver != nil {
+		info, err := resolver.NewRequestInfo(req)
+		if err == nil && info != nil {
+			return handlerLabel(info)
+		}
+	}
+	if info, ok := genericrequest.RequestInfoFrom(req.Context()); ok && info != nil {
+		return handlerLabel(info)
+	}
+	return pathHandler(req.URL.Path)
+}
+
+func handlerLabel(info *genericrequest.RequestInfo) string {
+	if info.IsResourceRequest {
+		return resourceHandler(info)
+	}
+	if info.Path != "" {
+		return info.Path
+	}
+	return "unknown"
+}
+
+func resourceHandler(info *genericrequest.RequestInfo) string {
+	// apps/v1/deployments, clusterpedia.io/v1beta1/resources, ...
+	var b strings.Builder
+	if info.APIGroup != "" {
+		b.WriteString(info.APIGroup)
+		b.WriteByte('/')
+	}
+	b.WriteString(info.APIVersion)
+	b.WriteByte('/')
+	b.WriteString(info.Resource)
+	if info.Subresource != "" {
+		b.WriteByte('/')
+		b.WriteString(info.Subresource)
+	}
+	return b.String()
+}
+
+func pathHandler(path string) string {
+	if path == "" || path == "/" {
+		return "/"
+	}
+	return strings.TrimRight(path, "/")
+}
+
+// responseRecorder captures status and bytes written.
+// Unwrap keeps http.ResponseController working; we intentionally do not
+// assert Hijacker/Flusher so HTTP/1 vs HTTP/2 capability stays with the
+// underlying writer.
+type responseRecorder struct {
+	http.ResponseWriter
+	status      int
+	bytes       int
+	wroteHeader bool
+}
+
+func (r *responseRecorder) WriteHeader(code int) {
+	if r.wroteHeader {
+		return
+	}
+	r.status = code
+	r.wroteHeader = true
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		r.WriteHeader(http.StatusOK)
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += n
+	return n, err
+}
+
+func (r *responseRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}
+
+func (r *responseRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/pkg/utils/filters/metrics_test.go
+++ b/pkg/utils/filters/metrics_test.go
@@ -1,0 +1,196 @@
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+func TestHandlerLabel_ResourceRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		info *genericrequest.RequestInfo
+		want string
+	}{
+		{
+			name: "core resource",
+			info: &genericrequest.RequestInfo{
+				IsResourceRequest: true,
+				APIGroup:          "",
+				APIVersion:        "v1",
+				Resource:          "pods",
+			},
+			want: "v1/pods",
+		},
+		{
+			name: "named group resource",
+			info: &genericrequest.RequestInfo{
+				IsResourceRequest: true,
+				APIGroup:          "apps",
+				APIVersion:        "v1",
+				Resource:          "deployments",
+			},
+			want: "apps/v1/deployments",
+		},
+		{
+			name: "with subresource",
+			info: &genericrequest.RequestInfo{
+				IsResourceRequest: true,
+				APIGroup:          "",
+				APIVersion:        "v1",
+				Resource:          "pods",
+				Subresource:       "status",
+			},
+			want: "v1/pods/status",
+		},
+		{
+			name: "clusterpedia resources entry",
+			info: &genericrequest.RequestInfo{
+				IsResourceRequest: true,
+				APIGroup:          "clusterpedia.io",
+				APIVersion:        "v1beta1",
+				Resource:          "resources",
+			},
+			want: "clusterpedia.io/v1beta1/resources",
+		},
+		{
+			name: "non-resource path",
+			info: &genericrequest.RequestInfo{
+				IsResourceRequest: false,
+				Path:              "/healthz",
+			},
+			want: "/healthz",
+		},
+		{
+			name: "non-resource empty path",
+			info: &genericrequest.RequestInfo{
+				IsResourceRequest: false,
+			},
+			want: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := handlerLabel(tc.info); got != tc.want {
+				t.Errorf("handlerLabel() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPathHandler(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"", "/"},
+		{"/", "/"},
+		{"/healthz", "/healthz"},
+		{"/metrics/", "/metrics"},
+		{"/apis/apps/v1/deployments", "/apis/apps/v1/deployments"},
+	}
+	for _, tc := range tests {
+		if got := pathHandler(tc.path); got != tc.want {
+			t.Errorf("pathHandler(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+type fakeResolver struct {
+	info *genericrequest.RequestInfo
+	err  error
+}
+
+func (f fakeResolver) NewRequestInfo(_ *http.Request) (*genericrequest.RequestInfo, error) {
+	return f.info, f.err
+}
+
+func TestResolveHandlerLabel(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/apis/apps/v1/namespaces/default/deployments/nginx", nil)
+
+	t.Run("uses resolver", func(t *testing.T) {
+		got := resolveHandlerLabel(req, fakeResolver{
+			info: &genericrequest.RequestInfo{
+				IsResourceRequest: true,
+				APIGroup:          "apps",
+				APIVersion:        "v1",
+				Resource:          "deployments",
+				Name:              "nginx",
+			},
+		})
+		// object name must not appear in the label
+		if got != "apps/v1/deployments" {
+			t.Errorf("got %q, want apps/v1/deployments", got)
+		}
+		if got == req.URL.Path {
+			t.Error("handler label should not be the raw path with object name")
+		}
+	})
+
+	t.Run("falls back to path without resolver", func(t *testing.T) {
+		got := resolveHandlerLabel(req, nil)
+		if got != "/apis/apps/v1/namespaces/default/deployments/nginx" {
+			t.Errorf("got %q", got)
+		}
+	})
+}
+
+func TestWithRequestMetrics_RecordsStatusAndSize(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("hello"))
+	})
+
+	h := WithRequestMetrics(inner, fakeResolver{
+		info: &genericrequest.RequestInfo{
+			IsResourceRequest: true,
+			APIGroup:          "apps",
+			APIVersion:        "v1",
+			Resource:          "deployments",
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/apis/apps/v1/namespaces/default/deployments", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusCreated)
+	}
+	if rec.Body.String() != "hello" {
+		t.Fatalf("body = %q, want hello", rec.Body.String())
+	}
+}
+
+func TestResponseRecorder_DefaultStatusOK(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	h := WithRequestMetrics(inner, fakeResolver{
+		info: &genericrequest.RequestInfo{IsResourceRequest: false, Path: "/healthz"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != "ok" {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+}
+
+func TestResponseRecorder_WriteHeaderOnce(t *testing.T) {
+	rw := &responseRecorder{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK}
+	rw.WriteHeader(http.StatusNotFound)
+	rw.WriteHeader(http.StatusInternalServerError)
+	if rw.status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 after first WriteHeader", rw.status)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The Clusterpedia APIServer already exposes some Kubernetes apiserver metrics, but those are geared toward resource verbs and groups. Operators still do not get a simple HTTP view of request volume, latency, response size, and concurrency by handler.

This adds four metrics on the shared legacyregistry so they appear on the existing /metrics endpoint:

* `clusterpedia_apiserver_request_total{code,handler,method}`
* `clusterpedia_apiserver_request_duration_seconds{code,handler,method}`
* `clusterpedia_apiserver_response_size_bytes{code,handler,method}`
* `clusterpedia_apiserver_request_inflight{handler}`

The handler label comes from RequestInfo (for example `apps/v1/deployments`) rather than the full URL, so object names do not blow up cardinality. The filter sits in the outer handler chain next to the existing request filters, so auth failures are still counted.

**Which issue(s) this PR fixes**:
Fixes #700

**Special notes for your reviewer**:

Unit tests cover handler label generation and the response status/size recorder. `go test ./pkg/...` and `go build ./cmd/apiserver` pass locally.

Happy to tweak metric names or label sets if you prefer a different shape.

**Does this PR introduce a user-facing change?**:
```release-note
Add Clusterpedia APIServer HTTP request metrics for count, duration, response size, and inflight requests.
```
