### PR TITLE
add Leo Shi as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@ Please keep the below list sorted in ascending order.
 
 | Maintainer  | GitHub ID        | Affiliation        | Email                            |
 |-------------|------------------|--------------------|----------------------------------|
-| Calvin Chen | @calvin0327      | DaoCloud           | <120380290@qq.com>               |
+| Calvin Chen | @calvin0327      | Individual         | <120380290@qq.com>               |
 | Iceber Gu   | @Iceber          | DaoCloud           | <caiwei95@hotmail.com>           |
-| wuyingjun   | @wuyingjun-lucky | China Mobile Cloud | <wuyingjun@cmss.chinamobile.com> |
+| Leo Shi     | @scydas          | DaoCloud           | <scyda@outlook.com>              |
+| Yingjun Wu  | @wuyingjun-lucky | China Mobile Cloud | <wuyingjun@cmss.chinamobile.com> |


### PR DESCRIPTION
https://github.com/clusterpedia-io/clusterpedia/pulls?q=is%3Apr+author%3Ascydas+is%3Aclosed

I propose adding `Chenyang Shi` as a maintainer, as he has contributed many features and fixed numerous bugs, and he will keep participating in Clusterpedia's maintenance.



https://github.com/scydas